### PR TITLE
feat: Auth API 및 카카오 로그인 구현

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,5 +9,6 @@ DB_PASSWORD=
 JWT_SECRET=your-secret-key-here-must-be-at-least-256-bits-long-for-hs256
 
 # Kakao OAuth
-KAKAO_CLIENT_ID=your-kakao-client-id
+KAKAO_CLIENT_ID=your-kakao-rest-api-key
+KAKAO_CLIENT_SECRET=your-kakao-client-secret
 KAKAO_REDIRECT_URI=http://localhost:8080/api/v1/auth/kakao/callback

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,9 @@ dependencies {
 	// Swagger (API 문서화)
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.0'
 	
+	// WebClient (카카오 API 호출용)
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+	
 	// Database
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	

--- a/src/main/java/com/leets/monifit_be/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/leets/monifit_be/domain/auth/controller/AuthController.java
@@ -1,0 +1,65 @@
+package com.leets.monifit_be.domain.auth.controller;
+
+import com.leets.monifit_be.domain.auth.dto.KakaoLoginRequest;
+import com.leets.monifit_be.domain.auth.dto.ReissueRequest;
+import com.leets.monifit_be.domain.auth.dto.TokenResponse;
+import com.leets.monifit_be.domain.auth.service.AuthService;
+import com.leets.monifit_be.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Auth", description = "인증 API")
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    /**
+     * 카카오 로그인 (회원가입 포함)
+     * 인증 없이 접근 가능
+     */
+    @Operation(summary = "카카오 로그인", description = "카카오 인가 코드로 로그인합니다. 신규 사용자는 자동 회원가입됩니다.")
+    @PostMapping("/kakao/login")
+    public ResponseEntity<ApiResponse<TokenResponse>> kakaoLogin(
+            @Valid @RequestBody KakaoLoginRequest request) {
+
+        TokenResponse response = authService.kakaoLogin(request.getCode());
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 토큰 재발급
+     * 인증 없이 접근 가능 (리프레시 토큰으로 인증)
+     */
+    @Operation(summary = "토큰 재발급", description = "리프레시 토큰으로 새로운 액세스 토큰과 리프레시 토큰을 발급받습니다.")
+    @PostMapping("/reissue")
+    public ResponseEntity<ApiResponse<TokenResponse>> reissue(
+            @Valid @RequestBody ReissueRequest request) {
+
+        TokenResponse response = authService.reissue(request.getRefreshToken());
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 로그아웃
+     * 인증 필요 (Authorization: Bearer {accessToken})
+     */
+    @Operation(summary = "로그아웃", description = "리프레시 토큰을 삭제하여 로그아웃합니다.")
+    @PostMapping("/logout")
+    public ResponseEntity<ApiResponse<Void>> logout(
+            @AuthenticationPrincipal Long memberId) {
+
+        authService.logout(memberId);
+        return ResponseEntity.ok(ApiResponse.success());
+    }
+}

--- a/src/main/java/com/leets/monifit_be/domain/auth/dto/KakaoLoginRequest.java
+++ b/src/main/java/com/leets/monifit_be/domain/auth/dto/KakaoLoginRequest.java
@@ -1,0 +1,16 @@
+package com.leets.monifit_be.domain.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Schema(description = "카카오 로그인 요청")
+@Getter
+@NoArgsConstructor
+public class KakaoLoginRequest {
+
+    @Schema(description = "카카오 인가 코드", example = "authorization_code_from_kakao")
+    @NotBlank(message = "인가 코드는 필수입니다")
+    private String code;
+}

--- a/src/main/java/com/leets/monifit_be/domain/auth/dto/KakaoTokenResponse.java
+++ b/src/main/java/com/leets/monifit_be/domain/auth/dto/KakaoTokenResponse.java
@@ -1,0 +1,32 @@
+package com.leets.monifit_be.domain.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 카카오 토큰 발급 API 응답
+ * https://kauth.kakao.com/oauth/token
+ */
+@Getter
+@NoArgsConstructor
+public class KakaoTokenResponse {
+
+    @JsonProperty("token_type")
+    private String tokenType;
+
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    @JsonProperty("expires_in")
+    private Integer expiresIn;
+
+    @JsonProperty("refresh_token")
+    private String refreshToken;
+
+    @JsonProperty("refresh_token_expires_in")
+    private Integer refreshTokenExpiresIn;
+
+    @JsonProperty("scope")
+    private String scope;
+}

--- a/src/main/java/com/leets/monifit_be/domain/auth/dto/KakaoUserInfo.java
+++ b/src/main/java/com/leets/monifit_be/domain/auth/dto/KakaoUserInfo.java
@@ -1,0 +1,78 @@
+package com.leets.monifit_be.domain.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 카카오 사용자 정보 API 응답
+ * https://kapi.kakao.com/v2/user/me
+ */
+@Getter
+@NoArgsConstructor
+public class KakaoUserInfo {
+
+    @JsonProperty("id")
+    private Long id; // 카카오 회원번호 (kakaoId)
+
+    @JsonProperty("connected_at")
+    private String connectedAt;
+
+    @JsonProperty("kakao_account")
+    private KakaoAccount kakaoAccount;
+
+    @Getter
+    @NoArgsConstructor
+    public static class KakaoAccount {
+
+        @JsonProperty("profile")
+        private Profile profile;
+
+        @JsonProperty("email")
+        private String email;
+
+        @JsonProperty("is_email_valid")
+        private Boolean isEmailValid;
+
+        @JsonProperty("is_email_verified")
+        private Boolean isEmailVerified;
+
+        @Getter
+        @NoArgsConstructor
+        public static class Profile {
+
+            @JsonProperty("nickname")
+            private String nickname;
+
+            @JsonProperty("profile_image_url")
+            private String profileImageUrl;
+
+            @JsonProperty("thumbnail_image_url")
+            private String thumbnailImageUrl;
+
+            @JsonProperty("is_default_image")
+            private Boolean isDefaultImage;
+        }
+    }
+
+    /**
+     * 닉네임 추출 (없으면 "사용자" 반환)
+     */
+    public String getNickname() {
+        if (kakaoAccount != null && kakaoAccount.getProfile() != null) {
+            String nickname = kakaoAccount.getProfile().getNickname();
+            return nickname != null ? nickname : "사용자";
+        }
+        return "사용자";
+    }
+
+    /**
+     * 이메일 추출 (없으면 빈 문자열 반환)
+     */
+    public String getEmail() {
+        if (kakaoAccount != null && kakaoAccount.getEmail() != null) {
+            return kakaoAccount.getEmail();
+        }
+        return "";
+    }
+}

--- a/src/main/java/com/leets/monifit_be/domain/auth/dto/ReissueRequest.java
+++ b/src/main/java/com/leets/monifit_be/domain/auth/dto/ReissueRequest.java
@@ -1,0 +1,16 @@
+package com.leets.monifit_be.domain.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Schema(description = "토큰 재발급 요청")
+@Getter
+@NoArgsConstructor
+public class ReissueRequest {
+
+    @Schema(description = "리프레시 토큰", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
+    @NotBlank(message = "리프레시 토큰은 필수입니다")
+    private String refreshToken;
+}

--- a/src/main/java/com/leets/monifit_be/domain/auth/dto/TokenResponse.java
+++ b/src/main/java/com/leets/monifit_be/domain/auth/dto/TokenResponse.java
@@ -1,0 +1,24 @@
+package com.leets.monifit_be.domain.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Schema(description = "토큰 응답")
+@Getter
+@Builder
+public class TokenResponse {
+
+    @Schema(description = "액세스 토큰", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
+    private String accessToken;
+
+    @Schema(description = "리프레시 토큰", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
+    private String refreshToken;
+
+    public static TokenResponse of(String accessToken, String refreshToken) {
+        return TokenResponse.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+}

--- a/src/main/java/com/leets/monifit_be/domain/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/leets/monifit_be/domain/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,39 @@
+package com.leets.monifit_be.domain.auth.repository;
+
+import com.leets.monifit_be.domain.auth.entity.RefreshToken;
+import com.leets.monifit_be.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+    /**
+     * 회원으로 리프레시 토큰 조회
+     */
+    Optional<RefreshToken> findByMember(Member member);
+
+    /**
+     * 회원 ID로 리프레시 토큰 조회
+     */
+    Optional<RefreshToken> findByMemberId(Long memberId);
+
+    /**
+     * 토큰 문자열로 리프레시 토큰 조회
+     * 토큰 재발급 시 사용
+     */
+    Optional<RefreshToken> findByToken(String token);
+
+    /**
+     * 회원의 리프레시 토큰 삭제 (로그아웃 시 사용)
+     */
+    @Modifying
+    void deleteByMember(Member member);
+
+    /**
+     * 회원 ID로 리프레시 토큰 삭제
+     */
+    @Modifying
+    void deleteByMemberId(Long memberId);
+}

--- a/src/main/java/com/leets/monifit_be/domain/auth/service/AuthService.java
+++ b/src/main/java/com/leets/monifit_be/domain/auth/service/AuthService.java
@@ -1,0 +1,153 @@
+package com.leets.monifit_be.domain.auth.service;
+
+import com.leets.monifit_be.domain.auth.dto.KakaoUserInfo;
+import com.leets.monifit_be.domain.auth.dto.TokenResponse;
+import com.leets.monifit_be.domain.auth.entity.RefreshToken;
+import com.leets.monifit_be.domain.auth.repository.RefreshTokenRepository;
+import com.leets.monifit_be.domain.member.entity.Member;
+import com.leets.monifit_be.domain.member.repository.MemberRepository;
+import com.leets.monifit_be.global.exception.BusinessException;
+import com.leets.monifit_be.global.exception.ErrorCode;
+import com.leets.monifit_be.global.jwt.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+/**
+ * 인증 서비스
+ * 카카오 로그인, 토큰 재발급, 로그아웃 처리
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final KakaoOAuthService kakaoOAuthService;
+    private final MemberRepository memberRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    /**
+     * 카카오 로그인 (회원가입 포함)
+     *
+     * @param code 카카오 인가 코드
+     * @return JWT 토큰 쌍 (액세스 토큰, 리프레시 토큰)
+     */
+    @Transactional
+    public TokenResponse kakaoLogin(String code) {
+        // 1. 카카오 인가 코드로 액세스 토큰 발급
+        String kakaoAccessToken = kakaoOAuthService.getAccessToken(code);
+
+        // 2. 카카오 액세스 토큰으로 사용자 정보 조회
+        KakaoUserInfo kakaoUserInfo = kakaoOAuthService.getUserInfo(kakaoAccessToken);
+
+        // 3. 회원 조회 또는 신규 가입
+        Member member = findOrCreateMember(kakaoUserInfo);
+
+        // 4. JWT 토큰 발급
+        String accessToken = jwtTokenProvider.createAccessToken(member.getId());
+        String refreshToken = jwtTokenProvider.createRefreshToken(member.getId());
+
+        // 5. 리프레시 토큰 저장 (기존 토큰이 있으면 갱신)
+        saveOrUpdateRefreshToken(member, refreshToken);
+
+        log.info("카카오 로그인 성공: memberId={}, kakaoId={}", member.getId(), kakaoUserInfo.getId());
+
+        return TokenResponse.of(accessToken, refreshToken);
+    }
+
+    /**
+     * 토큰 재발급
+     *
+     * @param refreshTokenValue 리프레시 토큰
+     * @return 새로운 JWT 토큰 쌍
+     */
+    @Transactional
+    public TokenResponse reissue(String refreshTokenValue) {
+        // 1. 리프레시 토큰 유효성 검증
+        if (!jwtTokenProvider.validateToken(refreshTokenValue)) {
+            log.warn("유효하지 않은 리프레시 토큰");
+            throw new BusinessException(ErrorCode.INVALID_TOKEN);
+        }
+
+        // 2. DB에서 리프레시 토큰 조회
+        RefreshToken refreshToken = refreshTokenRepository.findByToken(refreshTokenValue)
+                .orElseThrow(() -> {
+                    log.warn("DB에 존재하지 않는 리프레시 토큰");
+                    return new BusinessException(ErrorCode.INVALID_TOKEN);
+                });
+
+        // 3. 만료 시간 확인
+        if (refreshToken.getExpiresAt().isBefore(LocalDateTime.now())) {
+            log.warn("만료된 리프레시 토큰: memberId={}", refreshToken.getMember().getId());
+            throw new BusinessException(ErrorCode.EXPIRED_TOKEN);
+        }
+
+        // 4. 새로운 토큰 발급
+        Member member = refreshToken.getMember();
+        String newAccessToken = jwtTokenProvider.createAccessToken(member.getId());
+        String newRefreshToken = jwtTokenProvider.createRefreshToken(member.getId());
+
+        // 5. 리프레시 토큰 갱신 (Rotation)
+        refreshToken.updateToken(
+                newRefreshToken,
+                LocalDateTime.now().plusSeconds(jwtTokenProvider.getRefreshTokenExpiration() / 1000));
+
+        log.info("토큰 재발급 성공: memberId={}", member.getId());
+
+        return TokenResponse.of(newAccessToken, newRefreshToken);
+    }
+
+    /**
+     * 로그아웃
+     *
+     * @param memberId 회원 ID
+     */
+    @Transactional
+    public void logout(Long memberId) {
+        // 리프레시 토큰 삭제
+        refreshTokenRepository.deleteByMemberId(memberId);
+        log.info("로그아웃 성공: memberId={}", memberId);
+    }
+
+    /**
+     * 회원 조회 또는 신규 가입
+     */
+    private Member findOrCreateMember(KakaoUserInfo kakaoUserInfo) {
+        return memberRepository.findByKakaoId(kakaoUserInfo.getId())
+                .orElseGet(() -> {
+                    log.info("신규 회원 가입: kakaoId={}", kakaoUserInfo.getId());
+                    Member newMember = Member.builder()
+                            .kakaoId(kakaoUserInfo.getId())
+                            .email(kakaoUserInfo.getEmail())
+                            .name(kakaoUserInfo.getNickname())
+                            .build();
+                    return memberRepository.save(newMember);
+                });
+    }
+
+    /**
+     * 리프레시 토큰 저장 또는 갱신
+     */
+    private void saveOrUpdateRefreshToken(Member member, String token) {
+        LocalDateTime expiresAt = LocalDateTime.now()
+                .plusSeconds(jwtTokenProvider.getRefreshTokenExpiration() / 1000);
+
+        refreshTokenRepository.findByMember(member)
+                .ifPresentOrElse(
+                        // 기존 토큰이 있으면 갱신
+                        existingToken -> existingToken.updateToken(token, expiresAt),
+                        // 없으면 새로 생성
+                        () -> {
+                            RefreshToken refreshToken = RefreshToken.builder()
+                                    .member(member)
+                                    .token(token)
+                                    .expiresAt(expiresAt)
+                                    .build();
+                            refreshTokenRepository.save(refreshToken);
+                        });
+    }
+}

--- a/src/main/java/com/leets/monifit_be/domain/auth/service/KakaoOAuthService.java
+++ b/src/main/java/com/leets/monifit_be/domain/auth/service/KakaoOAuthService.java
@@ -1,0 +1,132 @@
+package com.leets.monifit_be.domain.auth.service;
+
+import com.leets.monifit_be.domain.auth.dto.KakaoTokenResponse;
+import com.leets.monifit_be.domain.auth.dto.KakaoUserInfo;
+import com.leets.monifit_be.global.exception.BusinessException;
+import com.leets.monifit_be.global.exception.ErrorCode;
+import io.netty.channel.ChannelOption;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+import io.netty.handler.timeout.WriteTimeoutHandler;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.netty.http.client.HttpClient;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * 카카오 OAuth API 호출 서비스
+ */
+@Slf4j
+@Service
+public class KakaoOAuthService {
+
+    private final WebClient webClient;
+    private final String clientId;
+    private final String clientSecret;
+    private final String redirectUri;
+    private final String tokenUri;
+    private final String userInfoUri;
+
+    public KakaoOAuthService(
+            @Value("${kakao.client-id}") String clientId,
+            @Value("${kakao.client-secret}") String clientSecret,
+            @Value("${kakao.redirect-uri}") String redirectUri,
+            @Value("${kakao.token-uri}") String tokenUri,
+            @Value("${kakao.user-info-uri}") String userInfoUri) {
+
+        // 타임아웃 설정 (연결 10초, 읽기 10초)
+        HttpClient httpClient = HttpClient.create()
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 10000)
+                .responseTimeout(Duration.ofSeconds(10))
+                .doOnConnected(conn -> conn
+                        .addHandlerLast(new ReadTimeoutHandler(10, TimeUnit.SECONDS))
+                        .addHandlerLast(new WriteTimeoutHandler(10, TimeUnit.SECONDS)));
+
+        this.webClient = WebClient.builder()
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .build();
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+        this.redirectUri = redirectUri;
+        this.tokenUri = tokenUri;
+        this.userInfoUri = userInfoUri;
+    }
+
+    /**
+     * 카카오 인가 코드로 액세스 토큰 발급
+     *
+     * @param code 카카오 인가 코드
+     * @return 카카오 액세스 토큰
+     */
+    public String getAccessToken(String code) {
+        try {
+            KakaoTokenResponse response = webClient.post()
+                    .uri(tokenUri)
+                    .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+                    .bodyValue(buildTokenRequest(code))
+                    .retrieve()
+                    .bodyToMono(KakaoTokenResponse.class)
+                    .block();
+
+            if (response == null || response.getAccessToken() == null) {
+                log.error("카카오 토큰 응답이 비어있습니다.");
+                throw new BusinessException(ErrorCode.KAKAO_AUTH_FAILED);
+            }
+
+            log.info("카카오 액세스 토큰 발급 성공");
+            return response.getAccessToken();
+
+        } catch (WebClientResponseException e) {
+            log.error("카카오 토큰 발급 실패: {}", e.getResponseBodyAsString());
+            throw new BusinessException(ErrorCode.KAKAO_AUTH_FAILED);
+        }
+    }
+
+    /**
+     * 카카오 액세스 토큰으로 사용자 정보 조회
+     *
+     * @param accessToken 카카오 액세스 토큰
+     * @return 카카오 사용자 정보
+     */
+    public KakaoUserInfo getUserInfo(String accessToken) {
+        try {
+            KakaoUserInfo userInfo = webClient.get()
+                    .uri(userInfoUri)
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                    .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+                    .retrieve()
+                    .bodyToMono(KakaoUserInfo.class)
+                    .block();
+
+            if (userInfo == null || userInfo.getId() == null) {
+                log.error("카카오 사용자 정보 응답이 비어있습니다.");
+                throw new BusinessException(ErrorCode.KAKAO_AUTH_FAILED);
+            }
+
+            log.info("카카오 사용자 정보 조회 성공: kakaoId={}", userInfo.getId());
+            return userInfo;
+
+        } catch (WebClientResponseException e) {
+            log.error("카카오 사용자 정보 조회 실패: {}", e.getResponseBodyAsString());
+            throw new BusinessException(ErrorCode.KAKAO_AUTH_FAILED);
+        }
+    }
+
+    /**
+     * 토큰 요청 바디 생성
+     */
+    private String buildTokenRequest(String code) {
+        return "grant_type=authorization_code" +
+                "&client_id=" + clientId +
+                "&client_secret=" + clientSecret +
+                "&redirect_uri=" + redirectUri +
+                "&code=" + code;
+    }
+}

--- a/src/main/java/com/leets/monifit_be/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/leets/monifit_be/domain/member/repository/MemberRepository.java
@@ -1,0 +1,20 @@
+package com.leets.monifit_be.domain.member.repository;
+
+import com.leets.monifit_be.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    /**
+     * 카카오 ID로 회원 조회
+     * 카카오 로그인 시 기존 회원인지 확인하는 용도
+     */
+    Optional<Member> findByKakaoId(Long kakaoId);
+
+    /**
+     * 카카오 ID로 회원 존재 여부 확인
+     */
+    boolean existsByKakaoId(Long kakaoId);
+}

--- a/src/main/java/com/leets/monifit_be/global/config/SecurityConfig.java
+++ b/src/main/java/com/leets/monifit_be/global/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.leets.monifit_be.global.config;
 
+import com.leets.monifit_be.global.jwt.JwtAuthenticationEntryPoint;
 import com.leets.monifit_be.global.jwt.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -10,6 +11,12 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
+import java.util.List;
 
 @Configuration
 @EnableWebSecurity
@@ -17,16 +24,24 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
         private final JwtAuthenticationFilter jwtAuthenticationFilter;
+        private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
         @Bean
         public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
                 http
+                                // CORS 설정 적용
+                                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+
                                 // CSRF 비활성화 (JWT 사용)
                                 .csrf(AbstractHttpConfigurer::disable)
 
                                 // 세션 사용 안 함 (Stateless)
                                 .sessionManagement(session -> session
                                                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+
+                                // 인증 실패 시 JSON 응답 반환
+                                .exceptionHandling(exception -> exception
+                                                .authenticationEntryPoint(jwtAuthenticationEntryPoint))
 
                                 // 요청 권한 설정
                                 .authorizeHttpRequests(auth -> auth
@@ -48,5 +63,37 @@ public class SecurityConfig {
                                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
                 return http.build();
+        }
+
+        /**
+         * CORS 설정
+         */
+        private CorsConfigurationSource corsConfigurationSource() {
+                CorsConfiguration configuration = new CorsConfiguration();
+
+                // 허용할 Origin (프론트엔드 주소)
+                configuration.setAllowedOrigins(Arrays.asList(
+                                "http://localhost:3000",
+                                "http://localhost:5173",
+                                "https://monifit.com"));
+
+                // 허용할 HTTP 메서드
+                configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+
+                // 허용할 헤더
+                configuration.setAllowedHeaders(List.of("*"));
+
+                // 인증 정보 포함 허용
+                configuration.setAllowCredentials(true);
+
+                // 노출할 헤더
+                configuration.setExposedHeaders(Arrays.asList("Authorization", "Content-Type"));
+
+                // preflight 캐시 시간
+                configuration.setMaxAge(3600L);
+
+                UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+                source.registerCorsConfiguration("/**", configuration);
+                return source;
         }
 }

--- a/src/main/java/com/leets/monifit_be/global/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/leets/monifit_be/global/jwt/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,45 @@
+package com.leets.monifit_be.global.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.leets.monifit_be.global.response.ApiResponse;
+import com.leets.monifit_be.global.response.ApiResponse.ErrorResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * JWT 인증 실패 시 JSON 응답 반환
+ * 401 Unauthorized 에러를 일관된 API 형식으로 반환
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException authException) throws IOException, ServletException {
+
+        log.warn("인증 실패: {}", authException.getMessage());
+
+        ErrorResponse error = new ErrorResponse("UNAUTHORIZED", "인증이 필요합니다");
+        ApiResponse<Void> apiResponse = ApiResponse.error(error);
+
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        response.getWriter().write(objectMapper.writeValueAsString(apiResponse));
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -28,7 +28,10 @@ jwt:
 # Kakao OAuth
 kakao:
   client-id: ${KAKAO_CLIENT_ID}
+  client-secret: ${KAKAO_CLIENT_SECRET}
   redirect-uri: ${KAKAO_REDIRECT_URI}
+  token-uri: https://kauth.kakao.com/oauth/token
+  user-info-uri: https://kapi.kakao.com/v2/user/me
 
 # Server
 server:


### PR DESCRIPTION
## 작업 내용
- **카카오 소셜 로그인 구현**
  - 카카오 인가 코드를 받아 액세스 토큰 발급 및 사용자 정보 조회
  - 신규 사용자 자동 회원가입 처리
  - JWT Access/Refresh Token 발급
- **토큰 재발급 (Rotation) 구현**
  - Refresh Token을 이용한 Access Token 재발급
  - 재발급 시 Refresh Token도 갱신하여 보안 강화 (RTR 적용)
- **로그아웃 구현**
  - DB에서 해당 사용자의 Refresh Token 삭제
- **Security 및 인증 관련 설정**
  - **SecurityConfig**: Stateless 세션 정책, JWT 필터 적용, CORS 설정
  - **JwtTokenProvider**: 토큰 생성, 검증, 만료 시간 관리
  - **JwtAuthenticationEntryPoint**: 인증 실패 시 401 JSON 응답 처리
- **기타**
  - Global Exception Handler: 비즈니스 예외 및 Validation 예외 처리
  - WebClient 타임아웃 설정 (10초)

## 변경된 파일
- `domain/auth/**`: Controller, Service, Repository, DTO, Entity 구현
- `domain/member/**`: Member 엔티티 및 Repository 구현
- `global/config/SecurityConfig.java`: 보안 설정 (CORS 포함)
- `global/jwt/**`: JWT 관련 유틸리티 및 필터
- `global/exception/**`: 전역 예외 처리 및 ErrorCode 정의

## 테스트 결과
- **카카오 로그인**: 신규/기존 회원 로그인 성공, JWT 발급 확인
- **토큰 재발급**: 유효한 Refresh Token으로 재발급 성공, 갱신 확인
- **로그아웃**: 요청 시 Refresh Token 삭제 확인
- **예외 처리**:
    - 잘못된 인가 코드 -> `401 KAKAO_AUTH_FAILED`
    - 잘못된/만료된 Refresh Token -> `401 INVALID_TOKEN`
    - 인증 없는 접근 -> `401 UNAUTHORIZED`

## 참고 사항 (Review Points)
- 카카오 디벨로퍼스에서 이름 가져오는 게 사업자 등록 하는 거 아니면 안돼서 닉네임 가져와서 member 테이블 안에 name 필드로 넣었습니다.
- **환경 변수 설정**: `.env` 파일에 다음 항목이 반드시 설정되어야 합니다. (환경변수 노션에 업로드 해놓겠습니다)
```properties
KAKAO_CLIENT_ID=...
KAKAO_CLIENT_SECRET=...
KAKAO_REDIRECT_URI=...
JWT_SECRET=...