### PR TITLE
[Feat] 회원 API 구현 (조회/수정/탈퇴)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,14 +1,15 @@
-# MoniFit 환경변수 설정
-# 이 파일을 복사해서 .env로 저장하고 본인 값 입력하세요
+# MoniFit 환경변수 설정 (로컬용)
+# 본인 환경에 맞게 수정하세요
 
 # Database
-DB_USERNAME=root
-DB_PASSWORD=
+DB_USERNAME=your_db_username
+DB_PASSWORD=your_db_password
 
 # JWT (최소 32자 이상)
-JWT_SECRET=your-secret-key-here-must-be-at-least-256-bits-long-for-hs256
+JWT_SECRET=your-jwt-secret-key-must-be-at-least-32-characters
 
 # Kakao OAuth
-KAKAO_CLIENT_ID=your-kakao-rest-api-key
-KAKAO_CLIENT_SECRET=your-kakao-client-secret
+KAKAO_CLIENT_ID=your_kakao_rest_api_key
+KAKAO_CLIENT_SECRET=your_kakao_client_secret
 KAKAO_REDIRECT_URI=http://localhost:8080/api/v1/auth/kakao/callback
+KAKAO_ADMIN_KEY=your_kakao_admin_key

--- a/src/main/java/com/leets/monifit_be/domain/auth/entity/RefreshToken.java
+++ b/src/main/java/com/leets/monifit_be/domain/auth/entity/RefreshToken.java
@@ -7,6 +7,8 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 import java.time.LocalDateTime;
 
@@ -22,6 +24,7 @@ public class RefreshToken extends BaseTimeEntity {
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false, unique = true)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Member member;
 
     @Column(nullable = false, length = 500)

--- a/src/main/java/com/leets/monifit_be/domain/budget/entity/BudgetPeriod.java
+++ b/src/main/java/com/leets/monifit_be/domain/budget/entity/BudgetPeriod.java
@@ -7,6 +7,8 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 import java.time.LocalDate;
 
@@ -22,6 +24,7 @@ public class BudgetPeriod extends BaseTimeEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Member member;
 
     @Column(name = "start_date", nullable = false)

--- a/src/main/java/com/leets/monifit_be/domain/member/controller/MemberController.java
+++ b/src/main/java/com/leets/monifit_be/domain/member/controller/MemberController.java
@@ -1,0 +1,69 @@
+package com.leets.monifit_be.domain.member.controller;
+
+import com.leets.monifit_be.domain.member.dto.MemberNameUpdateRequest;
+import com.leets.monifit_be.domain.member.dto.MemberResponse;
+import com.leets.monifit_be.domain.member.service.MemberService;
+import com.leets.monifit_be.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * 회원 API 컨트롤러
+ * - GET /members/me: 내 정보 조회 (마이페이지)
+ * - PATCH /members/me/name: 이름 수정
+ * - DELETE /members/me: 계정 삭제 (탈퇴, 카카오 연동 해제 포함)
+ */
+@Tag(name = "Member", description = "회원 API")
+@RestController
+@RequestMapping("/api/v1/members")
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberService memberService;
+
+    /**
+     * 내 정보 조회 (마이페이지)
+     * 인증 필요 (Authorization: Bearer {accessToken})
+     */
+    @Operation(summary = "내 정보 조회", description = "로그인한 사용자의 정보를 조회합니다 (마이페이지)")
+    @GetMapping("/me")
+    public ResponseEntity<ApiResponse<MemberResponse>> getMyInfo(
+            @AuthenticationPrincipal Long memberId) {
+
+        MemberResponse response = memberService.getMyInfo(memberId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 이름 수정
+     * 인증 필요 (Authorization: Bearer {accessToken})
+     */
+    @Operation(summary = "이름 수정", description = "로그인한 사용자의 이름을 수정합니다")
+    @PatchMapping("/me/name")
+    public ResponseEntity<ApiResponse<MemberResponse>> updateName(
+            @AuthenticationPrincipal Long memberId,
+            @Valid @RequestBody MemberNameUpdateRequest request) {
+
+        MemberResponse response = memberService.updateName(memberId, request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 계정 삭제 (탈퇴)
+     * 카카오 연동 해제 포함
+     * 인증 필요 (Authorization: Bearer {accessToken})
+     */
+    @Operation(summary = "계정 삭제", description = "회원 탈퇴합니다. 카카오 연동 해제가 함께 진행됩니다")
+    @DeleteMapping("/me")
+    public ResponseEntity<ApiResponse<Void>> deleteMember(
+            @AuthenticationPrincipal Long memberId) {
+
+        memberService.deleteMember(memberId);
+        return ResponseEntity.ok(ApiResponse.success());
+    }
+}

--- a/src/main/java/com/leets/monifit_be/domain/member/dto/MemberNameUpdateRequest.java
+++ b/src/main/java/com/leets/monifit_be/domain/member/dto/MemberNameUpdateRequest.java
@@ -1,0 +1,17 @@
+package com.leets.monifit_be.domain.member.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+/**
+ * 회원 이름 수정 요청 DTO
+ * PATCH /members/me/name 요청에 사용
+ */
+@Getter
+public class MemberNameUpdateRequest {
+
+    @NotBlank(message = "이름은 필수입니다")
+    @Size(max = 50, message = "이름은 50자 이하여야 합니다")
+    private String name;
+}

--- a/src/main/java/com/leets/monifit_be/domain/member/dto/MemberResponse.java
+++ b/src/main/java/com/leets/monifit_be/domain/member/dto/MemberResponse.java
@@ -1,0 +1,33 @@
+package com.leets.monifit_be.domain.member.dto;
+
+import com.leets.monifit_be.domain.member.entity.Member;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+/**
+ * 회원 정보 응답 DTO
+ * GET /members/me 응답에 사용
+ */
+@Getter
+@Builder
+public class MemberResponse {
+
+    private Long id;
+    private String email;
+    private String name;
+    private LocalDateTime createdAt;
+
+    /**
+     * Entity -> DTO 변환
+     */
+    public static MemberResponse from(Member member) {
+        return MemberResponse.builder()
+                .id(member.getId())
+                .email(member.getEmail())
+                .name(member.getName())
+                .createdAt(member.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/leets/monifit_be/domain/member/service/MemberService.java
+++ b/src/main/java/com/leets/monifit_be/domain/member/service/MemberService.java
@@ -1,0 +1,96 @@
+package com.leets.monifit_be.domain.member.service;
+
+import com.leets.monifit_be.domain.auth.repository.RefreshTokenRepository;
+import com.leets.monifit_be.domain.auth.service.KakaoOAuthService;
+import com.leets.monifit_be.domain.member.dto.MemberNameUpdateRequest;
+import com.leets.monifit_be.domain.member.dto.MemberResponse;
+import com.leets.monifit_be.domain.member.entity.Member;
+import com.leets.monifit_be.domain.member.repository.MemberRepository;
+import com.leets.monifit_be.global.exception.BusinessException;
+import com.leets.monifit_be.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 회원 서비스
+ * 내 정보 조회, 이름 수정, 계정 삭제(탈퇴) 처리
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final KakaoOAuthService kakaoOAuthService;
+
+    /**
+     * 내 정보 조회
+     *
+     * @param memberId 회원 ID (JWT에서 추출)
+     * @return 회원 정보 응답
+     */
+    @Transactional(readOnly = true)
+    public MemberResponse getMyInfo(Long memberId) {
+        Member member = findMemberById(memberId);
+        log.info("내 정보 조회: memberId={}", memberId);
+        return MemberResponse.from(member);
+    }
+
+    /**
+     * 이름 수정
+     *
+     * @param memberId 회원 ID (JWT에서 추출)
+     * @param request  이름 수정 요청
+     * @return 수정된 회원 정보 응답
+     */
+    @Transactional
+    public MemberResponse updateName(Long memberId, MemberNameUpdateRequest request) {
+        Member member = findMemberById(memberId);
+        member.updateName(request.getName());
+
+        log.info("이름 수정 완료: memberId={}, newName={}", memberId, request.getName());
+        return MemberResponse.from(member);
+    }
+
+    /**
+     * 계정 삭제 (탈퇴)
+     * 카카오 연동 해제 포함
+     *
+     * @param memberId 회원 ID (JWT에서 추출)
+     */
+    @Transactional
+    public void deleteMember(Long memberId) {
+        Member member = findMemberById(memberId);
+
+        // 1. 카카오 연동 해제
+        try {
+            kakaoOAuthService.unlinkUser(member.getKakaoId());
+            log.info("카카오 연동 해제 완료: kakaoId={}", member.getKakaoId());
+        } catch (Exception e) {
+            log.warn("카카오 연동 해제 실패 (계속 진행): kakaoId={}, error={}",
+                    member.getKakaoId(), e.getMessage());
+            // 카카오 연동 해제 실패해도 회원 삭제는 진행
+        }
+
+        // 2. 리프레시 토큰 삭제
+        refreshTokenRepository.deleteByMemberId(memberId);
+
+        // 3. 회원 삭제
+        // - BudgetPeriod, Expense는 DB FK의 ON DELETE CASCADE로 함께 삭제됨
+        // - DDL: FOREIGN KEY (member_id) REFERENCES member(id) ON DELETE CASCADE
+        memberRepository.delete(member);
+
+        log.info("회원 탈퇴 완료: memberId={}", memberId);
+    }
+
+    /**
+     * 회원 ID로 회원 조회
+     */
+    private Member findMemberById(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/leets/monifit_be/global/exception/ErrorCode.java
+++ b/src/main/java/com/leets/monifit_be/global/exception/ErrorCode.java
@@ -18,6 +18,7 @@ public enum ErrorCode {
     INVALID_TOKEN(401, "INVALID_TOKEN", "유효하지 않은 토큰입니다"),
     EXPIRED_TOKEN(401, "EXPIRED_TOKEN", "만료된 토큰입니다"),
     KAKAO_AUTH_FAILED(401, "KAKAO_AUTH_FAILED", "카카오 인증에 실패했습니다"),
+    KAKAO_UNLINK_FAILED(500, "KAKAO_UNLINK_FAILED", "카카오 연동 해제에 실패했습니다"),
 
     // Member
     MEMBER_NOT_FOUND(404, "MEMBER_NOT_FOUND", "사용자를 찾을 수 없습니다"),

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -32,6 +32,8 @@ kakao:
   redirect-uri: ${KAKAO_REDIRECT_URI}
   token-uri: https://kauth.kakao.com/oauth/token
   user-info-uri: https://kapi.kakao.com/v2/user/me
+  admin-key: ${KAKAO_ADMIN_KEY}
+  unlink-uri: https://kapi.kakao.com/v1/user/unlink
 
 # Server
 server:


### PR DESCRIPTION
## 작업 내용

### 구현된 API
| Method | Endpoint | 설명 |
|--------|----------|------|
| GET | /api/v1/members/me | 내 정보 조회 (마이페이지) |
| PATCH | /api/v1/members/me/name | 이름 수정 |
| DELETE | /api/v1/members/me | 계정 삭제 (탈퇴, 카카오 연동 해제 포함) |

### 생성된 파일
- member/controller/MemberController.java
- member/service/MemberService.java
- member/dto/MemberResponse.java
- member/dto/MemberNameUpdateRequest.java

### 수정된 파일
- KakaoOAuthService.java: unlinkUser() 메서드 추가
- ErrorCode.java: KAKAO_UNLINK_FAILED 에러 코드 추가
- BudgetPeriod.java: @OnDelete(CASCADE) 추가
- RefreshToken.java: @OnDelete(CASCADE) 추가
- application.yaml: kakao.admin-key, kakao.unlink-uri 설정 추가
- .env.example: KAKAO_ADMIN_KEY 환경변수 추가

## 체크리스트
- API 명세서 기준 구현 완료
- 코딩 컨벤션 준수
- ERD 명세서 대로 DTO 필드 구성
- 예외 처리 구현 (401, 400, 404)
- 빌드 성공 확인

## 요구사항 대비 참고 사항

### 1. 마이페이지 "시작일" 필드
> 요구사항정의서 9-1: "시작일: 최초 목표 예산 설정 시작일 표시"

- 현재 MemberResponse에는 createdAt(회원가입일)만 포함
- "최초 목표 예산 설정 시작일"은 BudgetPeriod 테이블에서 조회 필요
- 예산기간 API 구현 후 추가 예정 또는 클라이언트에서 별도 API로 조회

### 2. 계정 삭제 시 "랜덤 숫자 4자리 확인"
> 요구사항정의서 9-3: "화면에 랜덤 숫자 4자리 표시, 동일하게 입력해야 삭제 버튼 활성화"

- 해당 로직은 프론트엔드에서 처리
- 백엔드는 DELETE /members/me API만 제공

## 기타 참고 사항
- 회원 탈퇴 시 카카오 연동 해제가 실패해도 탈퇴는 진행됩니다 (로그 경고만)
- DB 초기화 후 서버 재실행 시 ON DELETE CASCADE FK 제약조건이 적용됩니다
- KAKAO_ADMIN_KEY 환경변수 설정 필요 (카카오 개발자콘솔 -> Admin 키)