### PR TITLE
[Feat] 예산 기간(Budget Period) API 구현

### DIFF
--- a/src/main/java/com/leets/monifit_be/domain/budget/controller/BudgetPeriodController.java
+++ b/src/main/java/com/leets/monifit_be/domain/budget/controller/BudgetPeriodController.java
@@ -1,0 +1,104 @@
+package com.leets.monifit_be.domain.budget.controller;
+
+import com.leets.monifit_be.domain.budget.dto.BudgetPeriodCreateRequest;
+import com.leets.monifit_be.domain.budget.dto.BudgetPeriodDetailResponse;
+import com.leets.monifit_be.domain.budget.dto.BudgetPeriodResponse;
+import com.leets.monifit_be.domain.budget.service.BudgetPeriodService;
+import com.leets.monifit_be.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+/**
+ * 예산 기간 API 컨트롤러
+ * - POST /budget-periods: 목표 기간/예산 설정 (생성)
+ * - GET /budget-periods/active: 활성 예산 기간 조회 (없으면 404)
+ * - GET /budget-periods/completed: 완료된 기간 목록 조회 (리포트용)
+ * - GET /budget-periods/{periodId}: 특정 기간 상세 조회 (리포트 상세)
+ */
+@Tag(name = "BudgetPeriod", description = "예산 기간 API")
+@RestController
+@RequestMapping("/api/v1/budget-periods")
+@RequiredArgsConstructor
+public class BudgetPeriodController {
+
+    private final BudgetPeriodService budgetPeriodService;
+
+    /**
+     * 예산 기간 생성
+     * 목표 기간 및 예산을 설정합니다.
+     * 시작일은 오늘 이후(오늘 포함)만 가능하며, 기간은 자동으로 30일로 설정됩니다.
+     * 이미 활성 기간이 있으면 생성할 수 없습니다.
+     *
+     * 인증 필요 (Authorization: Bearer {accessToken})
+     */
+    @Operation(summary = "예산 기간 생성", description = "목표 기간 및 예산을 설정합니다. 기간은 시작일로부터 자동으로 30일 설정됩니다.")
+    @PostMapping
+    public ResponseEntity<ApiResponse<BudgetPeriodResponse>> create(
+            @AuthenticationPrincipal Long memberId,
+            @Valid @RequestBody BudgetPeriodCreateRequest request) {
+
+        BudgetPeriodResponse response = budgetPeriodService.create(memberId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
+    }
+
+    /**
+     * 활성 예산 기간 조회
+     * 현재 활성화된 예산 기간을 조회합니다.
+     * 활성 기간이 없으면 404를 반환합니다.
+     * 클라이언트는 404 응답 시 목표 설정 화면으로 이동해야 합니다.
+     *
+     * 인증 필요 (Authorization: Bearer {accessToken})
+     */
+    @Operation(summary = "활성 예산 기간 조회", description = "현재 활성화된 예산 기간을 조회합니다. 활성 기간이 없으면 404를 반환합니다.")
+    @GetMapping("/active")
+    public ResponseEntity<ApiResponse<BudgetPeriodResponse>> getActivePeriod(
+            @AuthenticationPrincipal Long memberId) {
+
+        BudgetPeriodResponse response = budgetPeriodService.getActivePeriod(memberId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 완료된 기간 목록 조회 (리포트용)
+     * 완료된 예산 기간 목록을 종료일 기준 최신순으로 조회합니다.
+     * 완료된 기간이 없으면 빈 배열을 반환합니다.
+     *
+     * 인증 필요 (Authorization: Bearer {accessToken})
+     */
+    @Operation(summary = "완료된 기간 목록 조회", description = "완료된 예산 기간 목록을 조회합니다. (리포트용)")
+    @GetMapping("/completed")
+    public ResponseEntity<ApiResponse<List<BudgetPeriodResponse>>> getCompletedPeriods(
+            @AuthenticationPrincipal Long memberId) {
+
+        List<BudgetPeriodResponse> response = budgetPeriodService.getCompletedPeriods(memberId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 특정 기간 상세 조회 (리포트 상세)
+     * 특정 예산 기간의 상세 정보를 조회합니다.
+     * 총 지출, 남은 예산, 절약 금액 등 계산된 정보가 포함됩니다.
+     * 본인의 기간만 조회할 수 있습니다.
+     *
+     * 인증 필요 (Authorization: Bearer {accessToken})
+     */
+    @Operation(summary = "기간 상세 조회", description = "특정 예산 기간의 상세 정보를 조회합니다. (리포트 상세)")
+    @GetMapping("/{periodId}")
+    public ResponseEntity<ApiResponse<BudgetPeriodDetailResponse>> getPeriodDetail(
+            @AuthenticationPrincipal Long memberId,
+            @Parameter(name = "periodId", description = "조회할 예산 기간 ID", required = true, in = ParameterIn.PATH) @PathVariable("periodId") Long periodId) {
+
+        BudgetPeriodDetailResponse response = budgetPeriodService.getPeriodDetail(memberId, periodId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+}

--- a/src/main/java/com/leets/monifit_be/domain/budget/dto/BudgetPeriodCreateRequest.java
+++ b/src/main/java/com/leets/monifit_be/domain/budget/dto/BudgetPeriodCreateRequest.java
@@ -1,0 +1,27 @@
+package com.leets.monifit_be.domain.budget.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+/**
+ * 예산 기간 생성 요청 DTO
+ * POST /budget-periods 요청에 사용
+ *
+ * 요구사항:
+ * - 시작일: 오늘 포함 이후 날짜만 선택 가능
+ * - 기간: 시작일부터 자동으로 30일 (시작일 + 29일)
+ * - 예산 금액: 필수 입력
+ */
+@Getter
+public class BudgetPeriodCreateRequest {
+
+    @NotNull(message = "시작일은 필수입니다")
+    private LocalDate startDate;
+
+    @NotNull(message = "예산 금액은 필수입니다")
+    @Min(value = 1, message = "예산 금액은 1원 이상이어야 합니다")
+    private Integer budgetAmount;
+}

--- a/src/main/java/com/leets/monifit_be/domain/budget/dto/BudgetPeriodDetailResponse.java
+++ b/src/main/java/com/leets/monifit_be/domain/budget/dto/BudgetPeriodDetailResponse.java
@@ -1,0 +1,67 @@
+package com.leets.monifit_be.domain.budget.dto;
+
+import com.leets.monifit_be.domain.budget.entity.BudgetPeriod;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+/**
+ * 예산 기간 상세 응답 DTO (리포트 상세용)
+ * GET /budget-periods/{periodId} 응답에 사용
+ *
+ * 리포트 상세에서 필요한 정보:
+ * - 기본 예산 기간 정보
+ * - 총 지출 금액 (계산)
+ * - 남은 예산 (계산)
+ * - 절약/초과 금액 (계산)
+ */
+@Getter
+@Builder
+public class BudgetPeriodDetailResponse {
+
+    private Long id;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private Integer budgetAmount;
+    private String status;
+    private String completionType;
+    private Boolean warningShown;
+    private LocalDateTime createdAt;
+
+    // 계산 필드 (Expense 구현 후 실제 값으로 대체 예정)
+    private Integer totalExpense; // 총 지출 금액
+    private Integer remainingBudget; // 남은 예산 (budgetAmount - totalExpense)
+    private Integer savedAmount; // 절약 금액 (양수면 절약, 음수면 초과)
+
+    /**
+     * Entity -> DTO 변환
+     * 현재는 지출 정보 없이 기본 정보만 반환
+     * totalExpense는 0, remainingBudget은 budgetAmount로 설정
+     *
+     * @param budgetPeriod 예산 기간 엔티티
+     * @param totalExpense 총 지출 금액 (Expense 집계 결과, 없으면 0)
+     */
+    public static BudgetPeriodDetailResponse from(BudgetPeriod budgetPeriod, Integer totalExpense) {
+        int expense = totalExpense != null ? totalExpense : 0;
+        int remaining = budgetPeriod.getBudgetAmount() - expense;
+        int saved = remaining; // 남은 금액이 곧 절약 금액 (초과 시 음수)
+
+        return BudgetPeriodDetailResponse.builder()
+                .id(budgetPeriod.getId())
+                .startDate(budgetPeriod.getStartDate())
+                .endDate(budgetPeriod.getEndDate())
+                .budgetAmount(budgetPeriod.getBudgetAmount())
+                .status(budgetPeriod.getStatus().name())
+                .completionType(budgetPeriod.getCompletionType() != null
+                        ? budgetPeriod.getCompletionType().name()
+                        : null)
+                .warningShown(budgetPeriod.getWarningShown())
+                .createdAt(budgetPeriod.getCreatedAt())
+                .totalExpense(expense)
+                .remainingBudget(remaining)
+                .savedAmount(saved)
+                .build();
+    }
+}

--- a/src/main/java/com/leets/monifit_be/domain/budget/dto/BudgetPeriodResponse.java
+++ b/src/main/java/com/leets/monifit_be/domain/budget/dto/BudgetPeriodResponse.java
@@ -1,0 +1,46 @@
+package com.leets.monifit_be.domain.budget.dto;
+
+import com.leets.monifit_be.domain.budget.entity.BudgetPeriod;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+/**
+ * 예산 기간 응답 DTO
+ * - POST /budget-periods 응답
+ * - GET /budget-periods/active 응답
+ * - GET /budget-periods/completed 목록 응답
+ */
+@Getter
+@Builder
+public class BudgetPeriodResponse {
+
+    private Long id;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private Integer budgetAmount;
+    private String status;
+    private String completionType;
+    private Boolean warningShown;
+    private LocalDateTime createdAt;
+
+    /**
+     * Entity -> DTO 변환
+     */
+    public static BudgetPeriodResponse from(BudgetPeriod budgetPeriod) {
+        return BudgetPeriodResponse.builder()
+                .id(budgetPeriod.getId())
+                .startDate(budgetPeriod.getStartDate())
+                .endDate(budgetPeriod.getEndDate())
+                .budgetAmount(budgetPeriod.getBudgetAmount())
+                .status(budgetPeriod.getStatus().name())
+                .completionType(budgetPeriod.getCompletionType() != null
+                        ? budgetPeriod.getCompletionType().name()
+                        : null)
+                .warningShown(budgetPeriod.getWarningShown())
+                .createdAt(budgetPeriod.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/leets/monifit_be/domain/budget/repository/BudgetPeriodRepository.java
+++ b/src/main/java/com/leets/monifit_be/domain/budget/repository/BudgetPeriodRepository.java
@@ -1,0 +1,38 @@
+package com.leets.monifit_be.domain.budget.repository;
+
+import com.leets.monifit_be.domain.budget.entity.BudgetPeriod;
+import com.leets.monifit_be.domain.budget.entity.PeriodStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 예산 기간 Repository
+ */
+public interface BudgetPeriodRepository extends JpaRepository<BudgetPeriod, Long> {
+
+    /**
+     * 회원의 특정 상태 기간 조회
+     * 활성 기간 조회에 사용
+     */
+    Optional<BudgetPeriod> findByMemberIdAndStatus(Long memberId, PeriodStatus status);
+
+    /**
+     * 회원의 특정 상태 기간 존재 여부 확인
+     * 활성 기간 중복 생성 방지에 사용
+     */
+    boolean existsByMemberIdAndStatus(Long memberId, PeriodStatus status);
+
+    /**
+     * 회원의 특정 상태 기간 목록 조회 (종료일 기준 최신순)
+     * 완료된 기간 목록 조회(리포트)에 사용
+     */
+    List<BudgetPeriod> findByMemberIdAndStatusOrderByEndDateDesc(Long memberId, PeriodStatus status);
+
+    /**
+     * 회원의 첫 번째(최초) 예산 기간 조회 (시작일 기준 오름차순, 1건)
+     * 마이페이지 "시작일" 표시에 사용
+     */
+    Optional<BudgetPeriod> findFirstByMemberIdOrderByStartDateAsc(Long memberId);
+}

--- a/src/main/java/com/leets/monifit_be/domain/budget/service/BudgetPeriodService.java
+++ b/src/main/java/com/leets/monifit_be/domain/budget/service/BudgetPeriodService.java
@@ -1,0 +1,168 @@
+package com.leets.monifit_be.domain.budget.service;
+
+import com.leets.monifit_be.domain.budget.dto.BudgetPeriodCreateRequest;
+import com.leets.monifit_be.domain.budget.dto.BudgetPeriodDetailResponse;
+import com.leets.monifit_be.domain.budget.dto.BudgetPeriodResponse;
+import com.leets.monifit_be.domain.budget.entity.BudgetPeriod;
+import com.leets.monifit_be.domain.budget.entity.PeriodStatus;
+import com.leets.monifit_be.domain.budget.repository.BudgetPeriodRepository;
+import com.leets.monifit_be.domain.member.entity.Member;
+import com.leets.monifit_be.domain.member.repository.MemberRepository;
+import com.leets.monifit_be.global.exception.BusinessException;
+import com.leets.monifit_be.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * 예산 기간 서비스
+ * - 예산 기간 생성, 조회, 목록 조회 처리
+ *
+ * 비즈니스 규칙:
+ * 1. 한 회원당 활성(ACTIVE) 기간은 하나만 존재 가능
+ * 2. 시작일은 오늘 이후(오늘 포함)만 가능
+ * 3. 기간은 자동으로 시작일 + 29일 (총 30일)
+ * 4. 활성 기간이 없으면 404 반환 (클라이언트가 목표 설정 화면으로 유도)
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class BudgetPeriodService {
+
+    private final BudgetPeriodRepository budgetPeriodRepository;
+    private final MemberRepository memberRepository;
+
+    /**
+     * 예산 기간 생성
+     * POST /budget-periods
+     *
+     * @param memberId 회원 ID (JWT에서 추출)
+     * @param request  생성 요청 (시작일, 예산 금액)
+     * @return 생성된 예산 기간 정보
+     */
+    @Transactional
+    public BudgetPeriodResponse create(Long memberId, BudgetPeriodCreateRequest request) {
+        // 1. 회원 조회
+        Member member = findMemberById(memberId);
+
+        // 2. 이미 활성 기간이 있는지 확인
+        if (budgetPeriodRepository.existsByMemberIdAndStatus(memberId, PeriodStatus.ACTIVE)) {
+            log.warn("활성 기간 중복 생성 시도: memberId={}", memberId);
+            throw new BusinessException(ErrorCode.ACTIVE_PERIOD_EXISTS);
+        }
+
+        // 3. 시작일 유효성 검증 (오늘 포함 이후만 가능)
+        LocalDate today = LocalDate.now();
+        if (request.getStartDate().isBefore(today)) {
+            log.warn("잘못된 시작일: memberId={}, startDate={}, today={}",
+                    memberId, request.getStartDate(), today);
+            throw new BusinessException(ErrorCode.INVALID_START_DATE);
+        }
+
+        // 4. 예산 기간 생성 및 저장
+        BudgetPeriod budgetPeriod = BudgetPeriod.builder()
+                .member(member)
+                .startDate(request.getStartDate())
+                .budgetAmount(request.getBudgetAmount())
+                .build();
+
+        BudgetPeriod savedPeriod = budgetPeriodRepository.save(budgetPeriod);
+
+        log.info("예산 기간 생성 완료: memberId={}, periodId={}, startDate={}, endDate={}, budget={}",
+                memberId, savedPeriod.getId(), savedPeriod.getStartDate(),
+                savedPeriod.getEndDate(), savedPeriod.getBudgetAmount());
+
+        return BudgetPeriodResponse.from(savedPeriod);
+    }
+
+    /**
+     * 활성 예산 기간 조회
+     * GET /budget-periods/active
+     *
+     * 활성 기간이 없으면 404 반환
+     * → 클라이언트는 404 응답 시 목표 설정 화면으로 이동
+     *
+     * @param memberId 회원 ID (JWT에서 추출)
+     * @return 활성 예산 기간 정보
+     */
+    @Transactional(readOnly = true)
+    public BudgetPeriodResponse getActivePeriod(Long memberId) {
+        BudgetPeriod activePeriod = budgetPeriodRepository
+                .findByMemberIdAndStatus(memberId, PeriodStatus.ACTIVE)
+                .orElseThrow(() -> {
+                    log.info("활성 기간 없음: memberId={}", memberId);
+                    return new BusinessException(ErrorCode.ACTIVE_PERIOD_NOT_FOUND);
+                });
+
+        log.info("활성 기간 조회: memberId={}, periodId={}", memberId, activePeriod.getId());
+        return BudgetPeriodResponse.from(activePeriod);
+    }
+
+    /**
+     * 완료된 기간 목록 조회 (리포트용)
+     * GET /budget-periods/completed
+     *
+     * 종료일 기준 최신순으로 정렬
+     *
+     * @param memberId 회원 ID (JWT에서 추출)
+     * @return 완료된 예산 기간 목록
+     */
+    @Transactional(readOnly = true)
+    public List<BudgetPeriodResponse> getCompletedPeriods(Long memberId) {
+        List<BudgetPeriod> completedPeriods = budgetPeriodRepository
+                .findByMemberIdAndStatusOrderByEndDateDesc(memberId, PeriodStatus.COMPLETED);
+
+        log.info("완료된 기간 목록 조회: memberId={}, count={}", memberId, completedPeriods.size());
+
+        return completedPeriods.stream()
+                .map(BudgetPeriodResponse::from)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 특정 기간 상세 조회 (리포트 상세)
+     * GET /budget-periods/{periodId}
+     *
+     * 본인의 기간만 조회 가능
+     *
+     * @param memberId 회원 ID (JWT에서 추출)
+     * @param periodId 조회할 기간 ID
+     * @return 예산 기간 상세 정보 (지출 집계 포함)
+     */
+    @Transactional(readOnly = true)
+    public BudgetPeriodDetailResponse getPeriodDetail(Long memberId, Long periodId) {
+        // 1. 예산 기간 조회
+        BudgetPeriod budgetPeriod = budgetPeriodRepository.findById(periodId)
+                .orElseThrow(() -> {
+                    log.warn("예산 기간 없음: periodId={}", periodId);
+                    return new BusinessException(ErrorCode.BUDGET_PERIOD_NOT_FOUND);
+                });
+
+        // 2. 본인 기간인지 검증 (다른 사람 기간은 "없음"으로 처리 - 보안)
+        if (!budgetPeriod.getMember().getId().equals(memberId)) {
+            log.warn("권한 없는 기간 조회 시도: memberId={}, periodId={}, ownerId={}",
+                    memberId, periodId, budgetPeriod.getMember().getId());
+            throw new BusinessException(ErrorCode.BUDGET_PERIOD_NOT_FOUND);
+        }
+
+        // 3. 총 지출 계산
+        // TODO: Expense 구현 후 실제 지출 합계로 대체
+        Integer totalExpense = 0;
+
+        log.info("기간 상세 조회: memberId={}, periodId={}", memberId, periodId);
+        return BudgetPeriodDetailResponse.from(budgetPeriod, totalExpense);
+    }
+
+    /**
+     * 회원 ID로 회원 조회
+     */
+    private Member findMemberById(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/leets/monifit_be/domain/member/dto/MemberResponse.java
+++ b/src/main/java/com/leets/monifit_be/domain/member/dto/MemberResponse.java
@@ -4,11 +4,17 @@ import com.leets.monifit_be.domain.member.entity.Member;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 /**
  * 회원 정보 응답 DTO
  * GET /members/me 응답에 사용
+ *
+ * 요구사항 9-1 마이페이지:
+ * - 이메일: 카카오 계정 이메일 주소 표시 (수정 불가)
+ * - 시작일: 최초 목표 예산 설정 시작일 표시
+ * - 이름: 현재 이름 표시 (수정 가능)
  */
 @Getter
 @Builder
@@ -18,16 +24,21 @@ public class MemberResponse {
     private String email;
     private String name;
     private LocalDateTime createdAt;
+    private LocalDate firstBudgetStartDate; // 최초 목표 예산 설정 시작일
 
     /**
      * Entity -> DTO 변환
+     *
+     * @param member               회원 엔티티
+     * @param firstBudgetStartDate 최초 예산 기간 시작일 (없으면 null)
      */
-    public static MemberResponse from(Member member) {
+    public static MemberResponse from(Member member, LocalDate firstBudgetStartDate) {
         return MemberResponse.builder()
                 .id(member.getId())
                 .email(member.getEmail())
                 .name(member.getName())
                 .createdAt(member.getCreatedAt())
+                .firstBudgetStartDate(firstBudgetStartDate)
                 .build();
     }
 }

--- a/src/main/java/com/leets/monifit_be/global/exception/ErrorCode.java
+++ b/src/main/java/com/leets/monifit_be/global/exception/ErrorCode.java
@@ -28,6 +28,7 @@ public enum ErrorCode {
     BUDGET_PERIOD_NOT_FOUND(404, "BUDGET_PERIOD_NOT_FOUND", "예산 기간을 찾을 수 없습니다"),
     ACTIVE_PERIOD_NOT_FOUND(404, "ACTIVE_PERIOD_NOT_FOUND", "활성화된 예산 기간이 없습니다"),
     ACTIVE_PERIOD_EXISTS(409, "ACTIVE_PERIOD_EXISTS", "이미 활성화된 예산 기간이 있습니다"),
+    INVALID_START_DATE(400, "INVALID_START_DATE", "시작일은 오늘 이후여야 합니다"),
 
     // Expense
     EXPENSE_NOT_FOUND(404, "EXPENSE_NOT_FOUND", "지출 내역을 찾을 수 없습니다"),


### PR DESCRIPTION
## 작업 내용

### 예산 기간 API (4개)
- POST /api/v1/budget-periods - 목표 기간/예산 설정 (생성)
- GET /api/v1/budget-periods/active - 활성 예산 기간 조회 (없으면 404)
- GET /api/v1/budget-periods/completed - 완료된 기간 목록 조회 (리포트용)
- GET /api/v1/budget-periods/{periodId} - 특정 기간 상세 조회 (리포트 상세)

### 회원 API 수정
- GET /api/v1/members/me 응답에 firstBudgetStartDate 필드 추가
  - 요구사항 9-1 마이페이지: "시작일: 최초 목표 예산 설정 시작일 표시"

## 추가/수정된 파일

### 신규 생성
- budget/controller/BudgetPeriodController.java
- budget/service/BudgetPeriodService.java
- budget/repository/BudgetPeriodRepository.java
- budget/dto/BudgetPeriodCreateRequest.java
- budget/dto/BudgetPeriodResponse.java
- budget/dto/BudgetPeriodDetailResponse.java

### 수정
- member/dto/MemberResponse.java - firstBudgetStartDate 필드 추가
- member/service/MemberService.java - 최초 예산 기간 시작일 조회 로직 추가
- global/exception/ErrorCode.java - INVALID_START_DATE 추가

## 비즈니스 규칙
- 한 회원당 활성(ACTIVE) 기간은 하나만 존재 가능
- 시작일은 오늘 이후(오늘 포함)만 가능
- 기간은 자동으로 시작일 + 29일 (총 30일)
- 활성 기간이 없으면 404 반환 -> 클라이언트가 목표 설정 화면으로 유도

## Expense 구현 후 보완 필요 사항

### 1. BudgetPeriodDetailResponse - 지출 집계 반영
현재 totalExpense = 0으로 고정. Expense 구현 후 실제 지출 합계로 대체 필요.

### 2. GET /budget-periods/completed - 리포트 목록에 지출 정보 추가
요구사항 6-2: "각 기간의 목표 예산 및 실제 지출 금액 표시"
-> Expense 구현 후 각 기간별 totalExpense 추가 필요

### 3. GET /budget-periods/{periodId} - 카테고리별 지출 내역 추가
요구사항 6-2: "5개 카테고리별 총 지출 금액 리스트"
-> Expense 구현 후 카테고리별 집계 추가 필요

### 4. 기간 자동 종료 로직
- 예산 초과 시 기간 종료: POST /expenses에서 처리 예정
- 마감일 도달 시 기간 종료: GET /dashboard 또는 스케줄러에서 처리 예정