### PR TITLE
[Refactor] API 명세서 및 요구사항 정합성 향상을 위한 전반적 코드 개선

### DIFF
--- a/src/main/java/com/leets/monifit_be/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/leets/monifit_be/domain/auth/controller/AuthController.java
@@ -16,6 +16,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.Map;
+
 @Tag(name = "Auth", description = "인증 API")
 @RestController
 @RequestMapping("/api/v1/auth")
@@ -56,10 +58,10 @@ public class AuthController {
      */
     @Operation(summary = "로그아웃", description = "리프레시 토큰을 삭제하여 로그아웃합니다.")
     @PostMapping("/logout")
-    public ResponseEntity<ApiResponse<Void>> logout(
+    public ResponseEntity<ApiResponse<Object>> logout(
             @AuthenticationPrincipal Long memberId) {
 
         authService.logout(memberId);
-        return ResponseEntity.ok(ApiResponse.success());
+        return ResponseEntity.ok(ApiResponse.success(Map.of("message", "로그아웃 되었습니다")));
     }
 }

--- a/src/main/java/com/leets/monifit_be/domain/auth/dto/TokenResponse.java
+++ b/src/main/java/com/leets/monifit_be/domain/auth/dto/TokenResponse.java
@@ -1,13 +1,12 @@
 package com.leets.monifit_be.domain.auth.dto;
 
-import com.leets.monifit_be.domain.member.entity.Member;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
 /**
  * 로그인/토큰 재발급 응답 DTO
- * API 명세서에 맞춰 모든 필드 포함
+ * API 명세서에 맞춰 정의
  */
 @Schema(description = "토큰 응답")
 @Getter
@@ -32,45 +31,15 @@ public class TokenResponse {
     @Schema(description = "예산 기간 설정 이력 여부 (첫 설정 시 '환영해요!' 메시지 표시용)")
     private Boolean hasEverSetBudget;
 
-    @Schema(description = "회원 정보")
-    private MemberInfo member;
-
     /**
-     * 회원 정보 내부 DTO
-     */
-    @Schema(description = "회원 기본 정보")
-    @Getter
-    @Builder
-    public static class MemberInfo {
-
-        @Schema(description = "회원 ID", example = "1")
-        private Long id;
-
-        @Schema(description = "회원 이름", example = "홍길동")
-        private String name;
-
-        @Schema(description = "이메일", example = "user@kakao.com")
-        private String email;
-
-        public static MemberInfo from(Member member) {
-            return MemberInfo.builder()
-                    .id(member.getId())
-                    .name(member.getName())
-                    .email(member.getEmail())
-                    .build();
-        }
-    }
-
-    /**
-     * 로그인 응답 생성 (전체 정보 포함)
+     * 로그인 응답 생성 (API 명세서 형식)
      */
     public static TokenResponse ofLogin(
             String accessToken,
             String refreshToken,
             int expiresInSeconds,
             boolean isNewMember,
-            boolean hasEverSetBudget,
-            Member member) {
+            boolean hasEverSetBudget) {
         return TokenResponse.builder()
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
@@ -78,7 +47,6 @@ public class TokenResponse {
                 .expiresIn(expiresInSeconds)
                 .isNewMember(isNewMember)
                 .hasEverSetBudget(hasEverSetBudget)
-                .member(MemberInfo.from(member))
                 .build();
     }
 

--- a/src/main/java/com/leets/monifit_be/domain/auth/service/AuthService.java
+++ b/src/main/java/com/leets/monifit_be/domain/auth/service/AuthService.java
@@ -69,8 +69,7 @@ public class AuthService {
                 refreshToken,
                 (int) (jwtTokenProvider.getAccessTokenExpiration() / 1000),
                 isNewMember,
-                hasEverSetBudget,
-                member);
+                hasEverSetBudget);
     }
 
     /**

--- a/src/main/java/com/leets/monifit_be/domain/budget/controller/BudgetPeriodController.java
+++ b/src/main/java/com/leets/monifit_be/domain/budget/controller/BudgetPeriodController.java
@@ -1,8 +1,6 @@
 package com.leets.monifit_be.domain.budget.controller;
 
-import com.leets.monifit_be.domain.budget.dto.BudgetPeriodCreateRequest;
-import com.leets.monifit_be.domain.budget.dto.BudgetPeriodDetailResponse;
-import com.leets.monifit_be.domain.budget.dto.BudgetPeriodResponse;
+import com.leets.monifit_be.domain.budget.dto.*;
 import com.leets.monifit_be.domain.budget.service.BudgetPeriodService;
 import com.leets.monifit_be.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -15,8 +13,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 /**
  * 예산 기간 API 컨트롤러
@@ -36,12 +32,12 @@ public class BudgetPeriodController {
     /**
      * 예산 기간 생성
      * 목표 기간 및 예산을 설정합니다.
-     * 시작일은 오늘 이후(오늘 포함)만 가능하며, 기간은 자동으로 30일로 설정됩니다.
+     * 시작일은 오늘만 가능하며, 기간은 자동으로 30일로 설정됩니다.
      * 이미 활성 기간이 있으면 생성할 수 없습니다.
      *
      * 인증 필요 (Authorization: Bearer {accessToken})
      */
-    @Operation(summary = "예산 기간 생성", description = "목표 기간 및 예산을 설정합니다. 기간은 시작일로부터 자동으로 30일 설정됩니다.")
+    @Operation(summary = "예산 기간 생성", description = "목표 기간 및 예산을 설정합니다. 시작일은 오늘, 기간은 30일로 자동 설정됩니다.")
     @PostMapping
     public ResponseEntity<ApiResponse<BudgetPeriodResponse>> create(
             @AuthenticationPrincipal Long memberId,
@@ -61,10 +57,10 @@ public class BudgetPeriodController {
      */
     @Operation(summary = "활성 예산 기간 조회", description = "현재 활성화된 예산 기간을 조회합니다. 활성 기간이 없으면 404를 반환합니다.")
     @GetMapping("/active")
-    public ResponseEntity<ApiResponse<BudgetPeriodResponse>> getActivePeriod(
+    public ResponseEntity<ApiResponse<ActiveBudgetPeriodResponse>> getActivePeriod(
             @AuthenticationPrincipal Long memberId) {
 
-        BudgetPeriodResponse response = budgetPeriodService.getActivePeriod(memberId);
+        ActiveBudgetPeriodResponse response = budgetPeriodService.getActivePeriod(memberId);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
@@ -77,10 +73,10 @@ public class BudgetPeriodController {
      */
     @Operation(summary = "완료된 기간 목록 조회", description = "완료된 예산 기간 목록을 조회합니다. (리포트용)")
     @GetMapping("/completed")
-    public ResponseEntity<ApiResponse<List<BudgetPeriodResponse>>> getCompletedPeriods(
+    public ResponseEntity<ApiResponse<CompletedPeriodsResponse>> getCompletedPeriods(
             @AuthenticationPrincipal Long memberId) {
 
-        List<BudgetPeriodResponse> response = budgetPeriodService.getCompletedPeriods(memberId);
+        CompletedPeriodsResponse response = budgetPeriodService.getCompletedPeriods(memberId);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 

--- a/src/main/java/com/leets/monifit_be/domain/budget/dto/ActiveBudgetPeriodResponse.java
+++ b/src/main/java/com/leets/monifit_be/domain/budget/dto/ActiveBudgetPeriodResponse.java
@@ -1,0 +1,137 @@
+package com.leets.monifit_be.domain.budget.dto;
+
+import com.leets.monifit_be.domain.budget.entity.BudgetPeriod;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+
+/**
+ * 활성 예산 기간 응답 DTO
+ * GET /budget-periods/active 응답에 사용
+ *
+ * 메인 화면 및 마이페이지에서 필요한 계산된 정보 포함
+ */
+@Schema(description = "활성 예산 기간 응답")
+@Getter
+@Builder
+public class ActiveBudgetPeriodResponse {
+
+    @Schema(description = "예산 기간 ID", example = "10")
+    private Long id;
+
+    @Schema(description = "시작일", example = "2026-01-22")
+    private LocalDate startDate;
+
+    @Schema(description = "종료일", example = "2026-02-20")
+    private LocalDate endDate;
+
+    @Schema(description = "목표 예산 (원)", example = "300000")
+    private Integer budgetAmount;
+
+    @Schema(description = "총 지출 금액 (원)", example = "120000")
+    private Integer totalExpense;
+
+    @Schema(description = "남은 예산 (원)", example = "180000")
+    private Integer remainingBudget;
+
+    @Schema(description = "절약 금액 (원, 초과 시 null)", example = "180000")
+    private Integer savedAmount;
+
+    @Schema(description = "초과 금액 (원, 절약 시 null)", example = "null")
+    private Integer exceededAmount;
+
+    @Schema(description = "사용률 (%)", example = "40.0")
+    private Double usageRate;
+
+    @Schema(description = "절약률 (%, 100 - usageRate)", example = "60.0")
+    private Double savingRate;
+
+    @Schema(description = "총 일수 (30일)", example = "30")
+    private Integer totalDays;
+
+    @Schema(description = "경과 일수", example = "10")
+    private Integer elapsedDays;
+
+    @Schema(description = "남은 일수", example = "20")
+    private Integer remainingDays;
+
+    @Schema(description = "기간 진행률 (%)", example = "33.3")
+    private Double progressRate;
+
+    @Schema(description = "일일 권장 지출 (원)", example = "9000")
+    private Integer dailyRecommendedExpense;
+
+    @Schema(description = "상태 (ACTIVE)", example = "ACTIVE")
+    private String status;
+
+    @Schema(description = "완료 유형 (활성 시 null)", example = "null")
+    private String completionType;
+
+    @Schema(description = "50% 경고 표시 여부", example = "false")
+    private Boolean warningShown;
+
+    /**
+     * Entity -> DTO 변환 (계산된 정보 포함)
+     *
+     * @param budgetPeriod 예산 기간 엔티티
+     * @param totalExpense 총 지출 금액
+     */
+    public static ActiveBudgetPeriodResponse from(BudgetPeriod budgetPeriod, long totalExpense) {
+        int budget = budgetPeriod.getBudgetAmount();
+        int expense = (int) totalExpense;
+        int remaining = budget - expense;
+
+        // 절약/초과 계산
+        Integer saved = remaining >= 0 ? remaining : null;
+        Integer exceeded = remaining < 0 ? Math.abs(remaining) : null;
+
+        // 사용률/절약률 계산
+        double usageRate = budget > 0 ? (double) expense / budget * 100 : 0;
+        double savingRate = 100 - usageRate;
+
+        // 일수 계산
+        LocalDate today = LocalDate.now();
+        LocalDate startDate = budgetPeriod.getStartDate();
+        LocalDate endDate = budgetPeriod.getEndDate();
+
+        int totalDays = (int) ChronoUnit.DAYS.between(startDate, endDate) + 1; // 30일
+        int elapsedDays = (int) ChronoUnit.DAYS.between(startDate, today) + 1;
+        if (elapsedDays < 1)
+            elapsedDays = 1;
+        if (elapsedDays > totalDays)
+            elapsedDays = totalDays;
+        int remainingDays = totalDays - elapsedDays;
+
+        // 진행률 계산
+        double progressRate = (double) elapsedDays / totalDays * 100;
+
+        // 일일 권장 지출 계산 (남은 예산 / 남은 일수)
+        int dailyRecommended = remainingDays > 0 && remaining > 0 ? remaining / remainingDays : 0;
+
+        return ActiveBudgetPeriodResponse.builder()
+                .id(budgetPeriod.getId())
+                .startDate(startDate)
+                .endDate(endDate)
+                .budgetAmount(budget)
+                .totalExpense(expense)
+                .remainingBudget(remaining)
+                .savedAmount(saved)
+                .exceededAmount(exceeded)
+                .usageRate(Math.round(usageRate * 10) / 10.0)
+                .savingRate(Math.round(savingRate * 10) / 10.0)
+                .totalDays(totalDays)
+                .elapsedDays(elapsedDays)
+                .remainingDays(remainingDays)
+                .progressRate(Math.round(progressRate * 10) / 10.0)
+                .dailyRecommendedExpense(dailyRecommended)
+                .status(budgetPeriod.getStatus().name())
+                .completionType(budgetPeriod.getCompletionType() != null
+                        ? budgetPeriod.getCompletionType().name()
+                        : null)
+                .warningShown(budgetPeriod.getWarningShown())
+                .build();
+    }
+}

--- a/src/main/java/com/leets/monifit_be/domain/budget/dto/BudgetPeriodCreateRequest.java
+++ b/src/main/java/com/leets/monifit_be/domain/budget/dto/BudgetPeriodCreateRequest.java
@@ -22,6 +22,6 @@ public class BudgetPeriodCreateRequest {
     private LocalDate startDate;
 
     @NotNull(message = "예산 금액은 필수입니다")
-    @Min(value = 1, message = "예산 금액은 1원 이상이어야 합니다")
+    @Min(value = 1, message = "예산 금액은 양수여야 합니다")
     private Integer budgetAmount;
 }

--- a/src/main/java/com/leets/monifit_be/domain/budget/dto/CategoryExpense.java
+++ b/src/main/java/com/leets/monifit_be/domain/budget/dto/CategoryExpense.java
@@ -1,0 +1,36 @@
+package com.leets.monifit_be.domain.budget.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 카테고리별 지출 내역 DTO
+ * BudgetPeriodDetailResponse에서 사용
+ */
+@Schema(description = "카테고리별 지출 내역")
+@Getter
+@Builder
+public class CategoryExpense {
+
+    @Schema(description = "카테고리 코드", example = "FOOD")
+    private String category;
+
+    @Schema(description = "카테고리 한글명", example = "식비")
+    private String categoryName;
+
+    @Schema(description = "지출 금액 (원)", example = "150000")
+    private Integer amount;
+
+    @Schema(description = "비율 (%)", example = "41.4")
+    private Double percentage;
+
+    public static CategoryExpense of(String category, String categoryName, int amount, double percentage) {
+        return CategoryExpense.builder()
+                .category(category)
+                .categoryName(categoryName)
+                .amount(amount)
+                .percentage(Math.round(percentage * 10) / 10.0)
+                .build();
+    }
+}

--- a/src/main/java/com/leets/monifit_be/domain/budget/dto/CompletedPeriodItem.java
+++ b/src/main/java/com/leets/monifit_be/domain/budget/dto/CompletedPeriodItem.java
@@ -1,0 +1,70 @@
+package com.leets.monifit_be.domain.budget.dto;
+
+import com.leets.monifit_be.domain.budget.entity.BudgetPeriod;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+/**
+ * 완료된 기간 목록 아이템 DTO
+ * CompletedPeriodsResponse 내부에서 사용
+ */
+@Schema(description = "완료된 기간 아이템")
+@Getter
+@Builder
+public class CompletedPeriodItem {
+
+    @Schema(description = "예산 기간 ID", example = "9")
+    private Long id;
+
+    @Schema(description = "시작일", example = "2025-12-23")
+    private LocalDate startDate;
+
+    @Schema(description = "종료일", example = "2026-01-21")
+    private LocalDate endDate;
+
+    @Schema(description = "목표 예산 (원)", example = "400000")
+    private Integer budgetAmount;
+
+    @Schema(description = "총 지출 금액 (원)", example = "362000")
+    private Integer totalExpense;
+
+    @Schema(description = "절약 금액 (원, SUCCESS인 경우)", example = "38000")
+    private Integer savedAmount;
+
+    @Schema(description = "초과 금액 (원, OVER_BUDGET인 경우)", example = "null")
+    private Integer exceededAmount;
+
+    @Schema(description = "완료 유형 (SUCCESS / OVER_BUDGET)", example = "SUCCESS")
+    private String completionType;
+
+    /**
+     * Entity -> DTO 변환
+     *
+     * @param budgetPeriod 예산 기간 엔티티
+     * @param totalExpense 총 지출 금액
+     */
+    public static CompletedPeriodItem from(BudgetPeriod budgetPeriod, long totalExpense) {
+        int budget = budgetPeriod.getBudgetAmount();
+        int expense = (int) totalExpense;
+        int difference = budget - expense;
+
+        Integer saved = difference >= 0 ? difference : null;
+        Integer exceeded = difference < 0 ? Math.abs(difference) : null;
+
+        return CompletedPeriodItem.builder()
+                .id(budgetPeriod.getId())
+                .startDate(budgetPeriod.getStartDate())
+                .endDate(budgetPeriod.getEndDate())
+                .budgetAmount(budget)
+                .totalExpense(expense)
+                .savedAmount(saved)
+                .exceededAmount(exceeded)
+                .completionType(budgetPeriod.getCompletionType() != null
+                        ? budgetPeriod.getCompletionType().name()
+                        : null)
+                .build();
+    }
+}

--- a/src/main/java/com/leets/monifit_be/domain/budget/dto/CompletedPeriodsResponse.java
+++ b/src/main/java/com/leets/monifit_be/domain/budget/dto/CompletedPeriodsResponse.java
@@ -1,0 +1,30 @@
+package com.leets.monifit_be.domain.budget.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+/**
+ * 완료된 기간 목록 응답 DTO
+ * GET /budget-periods/completed 응답에 사용
+ */
+@Schema(description = "완료된 기간 목록 응답")
+@Getter
+@Builder
+public class CompletedPeriodsResponse {
+
+    @Schema(description = "완료된 기간 목록")
+    private List<CompletedPeriodItem> periods;
+
+    @Schema(description = "총 완료 기간 수", example = "2")
+    private Integer totalCount;
+
+    public static CompletedPeriodsResponse of(List<CompletedPeriodItem> periods) {
+        return CompletedPeriodsResponse.builder()
+                .periods(periods)
+                .totalCount(periods.size())
+                .build();
+    }
+}

--- a/src/main/java/com/leets/monifit_be/domain/expense/controller/ExpenseController.java
+++ b/src/main/java/com/leets/monifit_be/domain/expense/controller/ExpenseController.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import jakarta.validation.Valid;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -32,7 +33,7 @@ public class ExpenseController {
     @PostMapping
     public ResponseEntity<ApiResponse<ExpenseCreateResponse>> createExpense(
             @AuthenticationPrincipal Long memberId,
-            @RequestBody ExpenseCreateRequest request) {
+            @Valid @RequestBody ExpenseCreateRequest request) {
         ExpenseCreateResponse response = expenseService.createExpense(memberId, request);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
     }
@@ -53,7 +54,7 @@ public class ExpenseController {
     public ResponseEntity<ApiResponse<ExpenseUpdateResponse>> updateExpense(
             @AuthenticationPrincipal Long memberId,
             @Parameter(description = "지출 ID") @PathVariable Long expenseId,
-            @RequestBody ExpenseUpdateRequest request) {
+            @Valid @RequestBody ExpenseUpdateRequest request) {
         ExpenseUpdateResponse response = expenseService.updateExpense(memberId, expenseId, request);
         return ResponseEntity.ok(ApiResponse.success(response));
     }

--- a/src/main/java/com/leets/monifit_be/domain/expense/dto/ExpenseCreateRequest.java
+++ b/src/main/java/com/leets/monifit_be/domain/expense/dto/ExpenseCreateRequest.java
@@ -1,17 +1,34 @@
 package com.leets.monifit_be.domain.expense.dto;
 
 import com.leets.monifit_be.domain.expense.entity.ExpenseCategory;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 
+/**
+ * 지출 입력 요청 DTO
+ * POST /expenses 요청에 사용
+ */
+@Schema(description = "지출 입력 요청")
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 public class ExpenseCreateRequest {
+
+    @Schema(description = "카테고리 (FOOD, SHOPPING, MEDICAL, LIVING, ETC)", example = "FOOD")
+    @NotNull(message = "카테고리를 선택해주세요")
     private ExpenseCategory category;
+
+    @Schema(description = "지출 금액 (원, 양수)", example = "15000")
+    @NotNull(message = "금액을 입력해주세요")
+    @Positive(message = "금액은 양수여야 합니다")
     private Integer amount;
+
+    @Schema(description = "지출 날짜 (기본값: 오늘)", example = "2026-01-28")
     private LocalDate spentDate;
 }

--- a/src/main/java/com/leets/monifit_be/domain/expense/dto/ExpenseUpdateRequest.java
+++ b/src/main/java/com/leets/monifit_be/domain/expense/dto/ExpenseUpdateRequest.java
@@ -1,12 +1,24 @@
 package com.leets.monifit_be.domain.expense.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+/**
+ * 지출 수정 요청 DTO
+ * PATCH /expenses/{expenseId} 요청에 사용
+ */
+@Schema(description = "지출 수정 요청")
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 public class ExpenseUpdateRequest {
+
+    @Schema(description = "새 금액 (원, 양수)", example = "20000")
+    @NotNull(message = "금액을 입력해주세요")
+    @Positive(message = "금액은 양수여야 합니다")
     private Integer amount;
 }

--- a/src/main/java/com/leets/monifit_be/domain/expense/service/DashboardService.java
+++ b/src/main/java/com/leets/monifit_be/domain/expense/service/DashboardService.java
@@ -59,17 +59,36 @@ public class DashboardService {
                 boolean showPeriodComplete = false;
                 DashboardResponse.PeriodCompleteDetail periodCompleteDetail = null;
                 if (LocalDate.now().isAfter(period.getEndDate())) {
-                        period.complete(CompletionType.SUCCESS);
+                        // 예산 초과 여부에 따라 completionType 결정
+                        CompletionType completionType = totalExpense <= budgetAmount
+                                        ? CompletionType.SUCCESS
+                                        : CompletionType.OVER_BUDGET;
+                        period.complete(completionType);
+
                         if (!period.getPeriodCompleteShown()) {
                                 showPeriodComplete = true;
                                 period.showPeriodComplete();
-                                periodCompleteDetail = DashboardResponse.PeriodCompleteDetail.builder()
-                                                .title("기간 종료! 🎉")
-                                                .message1("이번 기간 동안 예산을 잘 관리했어요")
-                                                .message2("총 ₩" + String.format("%,d",
-                                                                savedAmount != null ? savedAmount : 0) + "을 절약했습니다")
-                                                .savedAmount(savedAmount)
-                                                .build();
+
+                                if (completionType == CompletionType.SUCCESS) {
+                                        periodCompleteDetail = DashboardResponse.PeriodCompleteDetail.builder()
+                                                        .title("기간 종료! 🎉")
+                                                        .message1("이번 기간 동안 예산을 잘 관리했어요")
+                                                        .message2("총 ₩" + String.format("%,d",
+                                                                        savedAmount != null ? savedAmount : 0)
+                                                                        + "을 절약했습니다")
+                                                        .savedAmount(savedAmount)
+                                                        .build();
+                                } else {
+                                        // 예산 초과 상태로 기간 종료
+                                        periodCompleteDetail = DashboardResponse.PeriodCompleteDetail.builder()
+                                                        .title("기간 종료")
+                                                        .message1("이번 기간은 예산을 초과했어요")
+                                                        .message2("₩" + String.format("%,d",
+                                                                        exceededAmount != null ? exceededAmount : 0)
+                                                                        + " 초과했습니다")
+                                                        .savedAmount(0)
+                                                        .build();
+                                }
                         }
 
                         // 기간 종료 시 hasPeriod = false

--- a/src/main/java/com/leets/monifit_be/domain/member/controller/MemberController.java
+++ b/src/main/java/com/leets/monifit_be/domain/member/controller/MemberController.java
@@ -1,6 +1,7 @@
 package com.leets.monifit_be.domain.member.controller;
 
 import com.leets.monifit_be.domain.member.dto.MemberNameUpdateRequest;
+import com.leets.monifit_be.domain.member.dto.MemberNameUpdateResponse;
 import com.leets.monifit_be.domain.member.dto.MemberResponse;
 import com.leets.monifit_be.domain.member.service.MemberService;
 import com.leets.monifit_be.global.response.ApiResponse;
@@ -45,11 +46,11 @@ public class MemberController {
      */
     @Operation(summary = "이름 수정", description = "로그인한 사용자의 이름을 수정합니다")
     @PatchMapping("/me/name")
-    public ResponseEntity<ApiResponse<MemberResponse>> updateName(
+    public ResponseEntity<ApiResponse<MemberNameUpdateResponse>> updateName(
             @AuthenticationPrincipal Long memberId,
             @Valid @RequestBody MemberNameUpdateRequest request) {
 
-        MemberResponse response = memberService.updateName(memberId, request);
+        MemberNameUpdateResponse response = memberService.updateName(memberId, request);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
@@ -60,10 +61,10 @@ public class MemberController {
      */
     @Operation(summary = "계정 삭제", description = "회원 탈퇴합니다. 카카오 연동 해제가 함께 진행됩니다")
     @DeleteMapping("/me")
-    public ResponseEntity<ApiResponse<Void>> deleteMember(
+    public ResponseEntity<Void> deleteMember(
             @AuthenticationPrincipal Long memberId) {
 
         memberService.deleteMember(memberId);
-        return ResponseEntity.ok(ApiResponse.success());
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/leets/monifit_be/domain/member/dto/MemberNameUpdateRequest.java
+++ b/src/main/java/com/leets/monifit_be/domain/member/dto/MemberNameUpdateRequest.java
@@ -12,6 +12,6 @@ import lombok.Getter;
 public class MemberNameUpdateRequest {
 
     @NotBlank(message = "이름은 필수입니다")
-    @Size(max = 50, message = "이름은 50자 이하여야 합니다")
+    @Size(min = 1, max = 50, message = "이름은 1~50자 사이여야 합니다")
     private String name;
 }

--- a/src/main/java/com/leets/monifit_be/domain/member/dto/MemberNameUpdateResponse.java
+++ b/src/main/java/com/leets/monifit_be/domain/member/dto/MemberNameUpdateResponse.java
@@ -1,0 +1,38 @@
+package com.leets.monifit_be.domain.member.dto;
+
+import com.leets.monifit_be.domain.member.entity.Member;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 이름 수정 응답 DTO
+ * PATCH /members/me/name 응답에 사용
+ * 
+ * API 명세서에 따라 간단한 정보만 반환
+ */
+@Schema(description = "이름 수정 응답")
+@Getter
+@Builder
+public class MemberNameUpdateResponse {
+
+    @Schema(description = "회원 ID", example = "1")
+    private Long id;
+
+    @Schema(description = "수정된 이름", example = "김모니")
+    private String name;
+
+    @Schema(description = "이메일", example = "user@kakao.com")
+    private String email;
+
+    /**
+     * Entity -> DTO 변환
+     */
+    public static MemberNameUpdateResponse from(Member member) {
+        return MemberNameUpdateResponse.builder()
+                .id(member.getId())
+                .name(member.getName())
+                .email(member.getEmail())
+                .build();
+    }
+}

--- a/src/main/java/com/leets/monifit_be/domain/member/dto/MemberResponse.java
+++ b/src/main/java/com/leets/monifit_be/domain/member/dto/MemberResponse.java
@@ -1,11 +1,13 @@
 package com.leets.monifit_be.domain.member.dto;
 
 import com.leets.monifit_be.domain.member.entity.Member;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.Period;
 
 /**
  * 회원 정보 응답 DTO
@@ -15,30 +17,115 @@ import java.time.LocalDateTime;
  * - 이메일: 카카오 계정 이메일 주소 표시 (수정 불가)
  * - 시작일: 최초 목표 예산 설정 시작일 표시
  * - 이름: 현재 이름 표시 (수정 가능)
+ * - 사용 기간: 시작일로부터 현재까지의 기간
+ * - 절약/초과 통계
  */
+@Schema(description = "회원 정보 응답 (마이페이지)")
 @Getter
 @Builder
 public class MemberResponse {
 
+    @Schema(description = "회원 ID", example = "1")
     private Long id;
-    private String email;
+
+    @Schema(description = "회원 이름", example = "홍길동")
     private String name;
+
+    @Schema(description = "카카오 이메일", example = "user@kakao.com")
+    private String email;
+
+    @Schema(description = "가입일", example = "2025-01-01T00:00:00")
     private LocalDateTime createdAt;
-    private LocalDate firstBudgetStartDate; // 최초 목표 예산 설정 시작일
+
+    @Schema(description = "예산 기간 설정 이력 여부", example = "true")
+    private boolean hasEverSetBudget;
+
+    @Schema(description = "사용 기간 정보 (예산 설정 이력이 없으면 null)")
+    private UsageInfo usage;
+
+    @Schema(description = "활동 요약 (예산 설정 이력이 없으면 null)")
+    private SummaryInfo summary;
 
     /**
-     * Entity -> DTO 변환
+     * 사용 기간 정보
+     */
+    @Schema(description = "사용 기간 정보")
+    @Getter
+    @Builder
+    public static class UsageInfo {
+        @Schema(description = "최초 예산 기간 시작일", example = "2025-01-01")
+        private LocalDate startDate;
+
+        @Schema(description = "사용 기간 (년)", example = "1")
+        private int years;
+
+        @Schema(description = "사용 기간 (개월)", example = "0")
+        private int months;
+    }
+
+    /**
+     * 활동 요약 정보
+     */
+    @Schema(description = "활동 요약 정보")
+    @Getter
+    @Builder
+    public static class SummaryInfo {
+        @Schema(description = "절약 달성 기간 횟수", example = "5")
+        private int savedPeriodCount;
+
+        @Schema(description = "예산 초과 기간 횟수", example = "2")
+        private int exceededPeriodCount;
+
+        @Schema(description = "총 누적 절약 금액 (원)", example = "150000")
+        private int totalSavedAmount;
+    }
+
+    /**
+     * Entity -> DTO 변환 (전체 정보)
      *
      * @param member               회원 엔티티
+     * @param hasEverSetBudget     예산 설정 이력 여부
      * @param firstBudgetStartDate 최초 예산 기간 시작일 (없으면 null)
+     * @param savedPeriodCount     절약 달성 기간 횟수
+     * @param exceededPeriodCount  예산 초과 기간 횟수
+     * @param totalSavedAmount     총 누적 절약 금액
      */
-    public static MemberResponse from(Member member, LocalDate firstBudgetStartDate) {
+    public static MemberResponse from(
+            Member member,
+            boolean hasEverSetBudget,
+            LocalDate firstBudgetStartDate,
+            int savedPeriodCount,
+            int exceededPeriodCount,
+            int totalSavedAmount) {
+
+        UsageInfo usageInfo = null;
+        SummaryInfo summaryInfo = null;
+
+        if (hasEverSetBudget && firstBudgetStartDate != null) {
+            // 사용 기간 계산
+            Period period = Period.between(firstBudgetStartDate, LocalDate.now());
+
+            usageInfo = UsageInfo.builder()
+                    .startDate(firstBudgetStartDate)
+                    .years(period.getYears())
+                    .months(period.getMonths())
+                    .build();
+
+            summaryInfo = SummaryInfo.builder()
+                    .savedPeriodCount(savedPeriodCount)
+                    .exceededPeriodCount(exceededPeriodCount)
+                    .totalSavedAmount(totalSavedAmount)
+                    .build();
+        }
+
         return MemberResponse.builder()
                 .id(member.getId())
-                .email(member.getEmail())
                 .name(member.getName())
+                .email(member.getEmail())
                 .createdAt(member.getCreatedAt())
-                .firstBudgetStartDate(firstBudgetStartDate)
+                .hasEverSetBudget(hasEverSetBudget)
+                .usage(usageInfo)
+                .summary(summaryInfo)
                 .build();
     }
 }

--- a/src/main/java/com/leets/monifit_be/domain/member/service/MemberService.java
+++ b/src/main/java/com/leets/monifit_be/domain/member/service/MemberService.java
@@ -2,8 +2,12 @@ package com.leets.monifit_be.domain.member.service;
 
 import com.leets.monifit_be.domain.auth.repository.RefreshTokenRepository;
 import com.leets.monifit_be.domain.auth.service.KakaoOAuthService;
+import com.leets.monifit_be.domain.budget.entity.BudgetPeriod;
+import com.leets.monifit_be.domain.budget.entity.PeriodStatus;
 import com.leets.monifit_be.domain.budget.repository.BudgetPeriodRepository;
+import com.leets.monifit_be.domain.expense.repository.ExpenseRepository;
 import com.leets.monifit_be.domain.member.dto.MemberNameUpdateRequest;
+import com.leets.monifit_be.domain.member.dto.MemberNameUpdateResponse;
 import com.leets.monifit_be.domain.member.dto.MemberResponse;
 import com.leets.monifit_be.domain.member.entity.Member;
 import com.leets.monifit_be.domain.member.repository.MemberRepository;
@@ -15,6 +19,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.List;
 
 /**
  * 회원 서비스
@@ -29,12 +34,14 @@ public class MemberService {
     private final RefreshTokenRepository refreshTokenRepository;
     private final KakaoOAuthService kakaoOAuthService;
     private final BudgetPeriodRepository budgetPeriodRepository;
+    private final ExpenseRepository expenseRepository;
 
     /**
      * 내 정보 조회
      * 요구사항 9-1 마이페이지:
      * - 이메일, 이름, 가입일
      * - 시작일: 최초 목표 예산 설정 시작일
+     * - 사용 기간, 절약/초과 통계
      *
      * @param memberId 회원 ID (JWT에서 추출)
      * @return 회원 정보 응답
@@ -43,14 +50,46 @@ public class MemberService {
     public MemberResponse getMyInfo(Long memberId) {
         Member member = findMemberById(memberId);
 
+        // 예산 기간 설정 이력 확인
+        boolean hasEverSetBudget = budgetPeriodRepository.existsByMemberId(memberId);
+
         // 최초 예산 기간 시작일 조회 (없으면 null)
         LocalDate firstBudgetStartDate = budgetPeriodRepository
                 .findFirstByMemberIdOrderByStartDateAsc(memberId)
-                .map(budgetPeriod -> budgetPeriod.getStartDate())
+                .map(BudgetPeriod::getStartDate)
                 .orElse(null);
 
-        log.info("내 정보 조회: memberId={}, firstBudgetStartDate={}", memberId, firstBudgetStartDate);
-        return MemberResponse.from(member, firstBudgetStartDate);
+        // 절약/초과 통계 계산 (완료된 기간만)
+        List<BudgetPeriod> completedPeriods = budgetPeriodRepository
+                .findByMemberIdAndStatusOrderByEndDateDesc(memberId, PeriodStatus.COMPLETED);
+
+        int savedPeriodCount = 0;
+        int exceededPeriodCount = 0;
+        int totalSavedAmount = 0;
+
+        for (BudgetPeriod period : completedPeriods) {
+            // 해당 기간의 총 지출 합계 조회
+            long totalSpent = expenseRepository.sumAmountByBudgetPeriod(period);
+            int savedAmount = period.getBudgetAmount() - (int) totalSpent;
+
+            if (savedAmount >= 0) {
+                savedPeriodCount++;
+                totalSavedAmount += savedAmount;
+            } else {
+                exceededPeriodCount++;
+            }
+        }
+
+        log.info("내 정보 조회: memberId={}, hasEverSetBudget={}, savedPeriodCount={}, exceededPeriodCount={}",
+                memberId, hasEverSetBudget, savedPeriodCount, exceededPeriodCount);
+
+        return MemberResponse.from(
+                member,
+                hasEverSetBudget,
+                firstBudgetStartDate,
+                savedPeriodCount,
+                exceededPeriodCount,
+                totalSavedAmount);
     }
 
     /**
@@ -58,21 +97,15 @@ public class MemberService {
      *
      * @param memberId 회원 ID (JWT에서 추출)
      * @param request  이름 수정 요청
-     * @return 수정된 회원 정보 응답
+     * @return 수정된 회원 정보 응답 (간단한 형식)
      */
     @Transactional
-    public MemberResponse updateName(Long memberId, MemberNameUpdateRequest request) {
+    public MemberNameUpdateResponse updateName(Long memberId, MemberNameUpdateRequest request) {
         Member member = findMemberById(memberId);
         member.updateName(request.getName());
 
-        // 최초 예산 기간 시작일 조회 (없으면 null)
-        LocalDate firstBudgetStartDate = budgetPeriodRepository
-                .findFirstByMemberIdOrderByStartDateAsc(memberId)
-                .map(budgetPeriod -> budgetPeriod.getStartDate())
-                .orElse(null);
-
         log.info("이름 수정 완료: memberId={}, newName={}", memberId, request.getName());
-        return MemberResponse.from(member, firstBudgetStartDate);
+        return MemberNameUpdateResponse.from(member);
     }
 
     /**

--- a/src/main/java/com/leets/monifit_be/global/exception/ErrorCode.java
+++ b/src/main/java/com/leets/monifit_be/global/exception/ErrorCode.java
@@ -15,9 +15,10 @@ public enum ErrorCode {
     INTERNAL_SERVER_ERROR(500, "INTERNAL_SERVER_ERROR", "서버 오류가 발생했습니다"),
 
     // Auth
-    INVALID_TOKEN(401, "INVALID_TOKEN", "유효하지 않은 토큰입니다"),
-    EXPIRED_TOKEN(401, "EXPIRED_TOKEN", "만료된 토큰입니다"),
-    KAKAO_AUTH_FAILED(401, "KAKAO_AUTH_FAILED", "카카오 인증에 실패했습니다"),
+    INVALID_TOKEN(401, "INVALID_TOKEN", "유효하지 않은 리프레시 토큰입니다"),
+    EXPIRED_TOKEN(401, "EXPIRED_TOKEN", "만료된 리프레시 토큰입니다"),
+    INVALID_AUTHORIZATION_CODE(400, "INVALID_AUTHORIZATION_CODE", "유효하지 않은 인가 코드입니다"),
+    KAKAO_AUTH_FAILED(500, "KAKAO_AUTH_FAILED", "카카오 로그인 처리 중 오류가 발생했습니다"),
     KAKAO_UNLINK_FAILED(500, "KAKAO_UNLINK_FAILED", "카카오 연동 해제에 실패했습니다"),
 
     // Member
@@ -28,7 +29,7 @@ public enum ErrorCode {
     BUDGET_PERIOD_NOT_FOUND(404, "BUDGET_PERIOD_NOT_FOUND", "예산 기간을 찾을 수 없습니다"),
     ACTIVE_PERIOD_NOT_FOUND(404, "ACTIVE_PERIOD_NOT_FOUND", "활성화된 예산 기간이 없습니다"),
     ACTIVE_PERIOD_EXISTS(409, "ACTIVE_PERIOD_EXISTS", "이미 활성화된 예산 기간이 있습니다"),
-    INVALID_START_DATE(400, "INVALID_START_DATE", "시작일은 오늘 이후여야 합니다"),
+    INVALID_START_DATE(400, "INVALID_START_DATE", "시작일은 오늘이어야 합니다"),
 
     // Expense
     EXPENSE_NOT_FOUND(404, "EXPENSE_NOT_FOUND", "지출 내역을 찾을 수 없습니다"),


### PR DESCRIPTION
### 개요
API 명세서(`API명세서.md`)와 실제 구현 코드 간의 불일치를 해소하고, 요구사항 정의서에 명시된 비즈니스 로직(통계 계산, 상태 처리 등)을 완벽하게 반영하기 위해 `Member`, `Budget`, `Dashboard`, `Expense` 도메인을 전반적으로 리팩토링했습니다.

### 주요 변경 사항

#### 1. 회원 (Member)
- **응답 DTO 재구성**: `MemberResponse`에 누적 사용 기간(`usage`), 저축/초과 횟수 및 총 저축액(`summary`) 필드 추가
- **이름 수정 API**: 응답 규격 간소화 (`MemberNameUpdateResponse`)
- **계정 삭제 API**: 성공 시 `204 No Content` 반환으로 수정
- **서비스 로직**: 마이페이지용 통계 계산 로직(`MemberService`) 구현

#### 2. 예산 기간 (Budget Period)
- **DTO 세분화**:
    - `ActiveBudgetPeriodResponse`: 활성 기간 조회 전용 (남은 예산, 사용률, 권장 지출액 등 계산 필드 포함)
    - `CompletedPeriodsResponse`: 완료된 기간 목록 래핑
    - `BudgetPeriodDetailResponse`: 카테고리별 지출 내역(`categoryExpenses`) 및 절약/초과 금액 분리
- **유효성 검사 강화**: 예산 기간 생성 시 **"시작일은 오늘만 가능"** 하도록 로직 수정 (`INVALID_START_DATE` 에러 메시지 변경)
- **서비스 로직**: 실제 `ExpenseRepository` 연동을 통한 지출 합계 계산 로직 구현

#### 3. 대시보드 (Dashboard)
- **기간 종료 로직 개선**: 종료 시점의 예산 초과 여부에 따라 `CompletionType`을 `SUCCESS` 또는 `OVER_BUDGET`으로 정확히 판단하도록 수정

#### 4. 지출 (Expense)
- **유효성 검사 추가**: `ExpenseCreateRequest`, `ExpenseUpdateRequest`에 `@NotNull`, `@Positive` 등 검증 어노테이션 추가 및 컨트롤러 `@Valid` 적용

### 테스트 결과
- 빌드 성공
- Swagger를 통한 API 명세 규격 일치 확인 완료

### 💬 기타
- API 명세서의 에러 메시지("양수여야 합니다", "오늘이어야 합니다" 등)와 코드를 일치시켰습니다.